### PR TITLE
Move clipboards.js outside of HTML and to HEAD

### DIFF
--- a/public/assets/js/main.js
+++ b/public/assets/js/main.js
@@ -154,7 +154,7 @@
         googleAnalytics();
     }
 
-    window.addEventListener('DOMContentLoaded', init, false);
+    init();
 
     window.addEventListener('resize', initTwitterTimeline, false);
 }))();

--- a/views/_partials/loadjs.pug
+++ b/views/_partials/loadjs.pug
@@ -1,10 +1,20 @@
 -var bootstrap = config.bootstrap.filter(function(o) { return o.current; })[0];
 -var jquery = config.javascript.filter(function(o) { return o.name === 'jquery'; })[0];
+-var clipboardjs = getVersionedPath('/assets/js/vendor/clipboard.min.js');
 
+| loadjs('#{clipboardjs}', 'clipboardjs', {
+|     numRetries: 3
+| });
 | loadjs(['#{jquery.uri}', '#{bootstrap.javascriptBundle}'], 'jquery', {
 |     async: false,
 |     numRetries: 3
 | });
 | loadjs.ready('jquery', function() {
 |     $('.ads-info-toggler').popover();
+| })
+| .ready('clipboardjs', function() {
+if (process.env.NODE_ENV === 'production')
+    include:uglify-js:babel /assets/js/main.js
+else
+    include:babel /assets/js/main.js
 | });

--- a/views/layout.pug
+++ b/views/layout.pug
@@ -80,14 +80,7 @@ html(lang='en', prefix='og: http://ogp.me/ns#', itemscope, itemtype='http://sche
         include _partials/footer.pug
 
         script(nonce=nonce)
-            include /assets/js/vendor/clipboard.min.js
             include /assets/js/vendor/loadjs.min.js
-
-            if (process.env.NODE_ENV === 'production')
-                include:uglify-js:babel /assets/js/main.js
-            else
-                include:babel /assets/js/main.js
-
             include _partials/loadjs.pug
 
 //- vim: ft=pug sw=4 sts=4 et:

--- a/views/layout.pug
+++ b/views/layout.pug
@@ -58,6 +58,10 @@ html(lang='en', prefix='og: http://ogp.me/ns#', itemscope, itemtype='http://sche
             else
                 include /assets/css/style.css
 
+        script(nonce=nonce)
+            include /assets/js/vendor/loadjs.min.js
+            include _partials/loadjs.pug
+
         block head
 
     body(class=bodyClass(title))
@@ -78,9 +82,5 @@ html(lang='en', prefix='og: http://ogp.me/ns#', itemscope, itemtype='http://sche
                             .twitter-timeline-custom
 
         include _partials/footer.pug
-
-        script(nonce=nonce)
-            include /assets/js/vendor/loadjs.min.js
-            include _partials/loadjs.pug
 
 //- vim: ft=pug sw=4 sts=4 et:


### PR DESCRIPTION
So, this is just a part of an older PR we reverted.

The goals are:

1. reduce the HTML size
2. improve TTFB
3. cache the clipboard.js file

Note than our main.js file is still inlined because I don't think there's a way we can do babel + uglify for an external file via Express.