### PR TITLE
Use the same version's CSS/JS files.

### DIFF
--- a/app.js
+++ b/app.js
@@ -223,6 +223,7 @@ app.locals.helpers = helpers;
 app.locals.config = config;
 app.locals.basedir = PUBLIC_DIR;
 app.locals.getVersionedPath = staticify.getVersionedPath;
+app.locals.semver = semver;
 
 // routes
 app.get('/fontawesome/', routes.renderFontawesome);

--- a/views/_partials/loadjs.pug
+++ b/views/_partials/loadjs.pug
@@ -1,14 +1,7 @@
-//- This is a little "hacky" but gets the job done.
-//- Assuming the versions follow the "a.b.c.d" scheme:
-//- 1. Gets the Bootswatch version, splits the first two parts in "." and then
-//-    joins them with "." as a string. So we end up with "a.b".
-//- 2. Then, we get the first Bootstrap version that starts with the Bootswatch
-//-    version we created in the previous step.
-//- This allows us to use Bootstrap patch versions.
 -
-    var bootswatchVersion = config.bootswatch4.version.split('.', 2).join('.');
+    var bootswatchVersion = semver.coerce(config.bootswatch4.version);
     var bootstrap = config.bootstrap.filter(function(o) {
-        return o.version.startsWith(bootswatchVersion);
+        return semver.satisfies(bootswatchVersion, '~' + o.version);
     })[0];
     var jquery = config.javascript.filter(function(o) {
         return o.name === 'jquery';

--- a/views/_partials/loadjs.pug
+++ b/views/_partials/loadjs.pug
@@ -1,4 +1,5 @@
--var bootstrap = config.bootstrap.filter(function(o) { return o.current; })[0];
+-var bootswatchVersion = config.bootswatch4.version;
+-var bootstrap = config.bootstrap.filter(function(o) { return o.version === bootswatchVersion; })[0];
 -var jquery = config.javascript.filter(function(o) { return o.name === 'jquery'; })[0];
 -var clipboardjs = getVersionedPath('/assets/js/vendor/clipboard.min.js');
 

--- a/views/_partials/loadjs.pug
+++ b/views/_partials/loadjs.pug
@@ -1,7 +1,19 @@
--var bootswatchVersion = config.bootswatch4.version;
--var bootstrap = config.bootstrap.filter(function(o) { return o.version === bootswatchVersion; })[0];
--var jquery = config.javascript.filter(function(o) { return o.name === 'jquery'; })[0];
--var clipboardjs = getVersionedPath('/assets/js/vendor/clipboard.min.js');
+//- This is a little "hacky" but gets the job done.
+//- Assuming the versions follow the "a.b.c.d" scheme:
+//- 1. Gets the Bootswatch version, splits the first two parts in "." and then
+//-    joins them with "." as a string. So we end up with "a.b".
+//- 2. Then, we get the first Bootstrap version that starts with the Bootswatch
+//-    version we created in the previous step.
+//- This allows us to use Bootstrap patch versions.
+-
+    var bootswatchVersion = config.bootswatch4.version.split('.', 2).join('.');
+    var bootstrap = config.bootstrap.filter(function(o) {
+        return o.version.startsWith(bootswatchVersion);
+    })[0];
+    var jquery = config.javascript.filter(function(o) {
+        return o.name === 'jquery';
+    })[0];
+    var clipboardjs = getVersionedPath('/assets/js/vendor/clipboard.min.js');
 
 | loadjs('#{clipboardjs}', 'clipboardjs', {
 |     numRetries: 3


### PR DESCRIPTION
This is just so that we are safe and we don't accidentally load incompatible versions.

So, now, the Bootstrap JS file loaded will be the same as the Bootswatch version.