### PR TITLE
Add `<meta name="twitter:widgets:csp" content="on">`.

### DIFF
--- a/views/layout.pug
+++ b/views/layout.pug
@@ -46,6 +46,8 @@ html(lang='en', prefix='og: http://ogp.me/ns#', itemscope, itemtype='http://sche
         meta(itemprop='description', content!=pageDescription)
         meta(itemprop='image', content=getVersionedPath('/assets/img/og.png'))
 
+        meta(name='twitter:widgets:csp', content='on')
+
         -var bootswatch = helpers.theme.fetch(config, theme);
         link(rel='stylesheet', href=bootswatch.uri, integrity=bootswatch.sri,
             crossorigin='anonymous')


### PR DESCRIPTION
https://dev.twitter.com/web/overview/widgets-webpage-properties#disable-functionality-which-may-trigger-content-security-policy-warnings

Apparently it doesn't seem to do anything for me, though.

Do we have someone who works for Twitter? I think this is a bug, because even with the `meta` specified, the Twitter script still does its own thing and 1) tests if CSP is active, but, 2) injects inline styles.

@ScottHelme: I don't suppose you have any idea how to fix this? :)