### PR TITLE
Specify a nonce for styles too.

### DIFF
--- a/config/helmet-csp.js
+++ b/config/helmet-csp.js
@@ -29,7 +29,8 @@ const CSP = {
         'stackpath.bootstrapcdn.com',
         'fonts.googleapis.com',
         '*.twimg.com',
-        'platform.twitter.com'
+        'platform.twitter.com',
+        (req, res) => `'nonce-${res.locals.nonce}'`
     ],
     imgSrc: [
         '\'self\'',

--- a/views/layout.pug
+++ b/views/layout.pug
@@ -29,7 +29,7 @@ html(lang='en', prefix='og: http://ogp.me/ns#', itemscope, itemtype='http://sche
 
         block stylesheets
 
-        style
+        style(nonce=nonce)
             if (process.env.NODE_ENV === 'production')
                 include:clean-css /assets/css/style.css
             else


### PR DESCRIPTION
**Do not merge!**

See also, #1019.

Here are the CSP errors we get:

```
Content Security Policy: The page’s settings blocked the loading of a resource at self (“style-src”). Source: .csptesti1523519318528659869 { visibilit....
Content Security Policy: The page’s settings blocked the loading of a resource at self (“style-src”). Source: max-width: 974px.
Content Security Policy: The page’s settings blocked the loading of a resource at self (“style-src”).
Content Security Policy: The page’s settings blocked the loading of a resource at self (“style-src”). Source: padding-bottom: 32.6489%.
Content Security Policy: The page’s settings blocked the loading of a resource at self (“style-src”).
Content Security Policy: The page’s settings blocked the loading of a resource at self (“style-src”). Source: max-width: 358px.
Content Security Policy: The page’s settings blocked the loading of a resource at self (“style-src”).
Content Security Policy: The page’s settings blocked the loading of a resource at self (“style-src”). Source: padding-bottom: 30.4469%.
Content Security Policy: The page’s settings blocked the loading of a resource at self (“style-src”).
Content Security Policy: The page’s settings blocked the loading of a resource at self (“style-src”).
```
