### PR TITLE
Cleaning up assertValidHTML

### DIFF
--- a/test/test_helper.js
+++ b/test/test_helper.js
@@ -96,12 +96,11 @@ function assertValidHTML(res, done) {
 
     validator(options, (err, data) => {
         if (err) {
-            console.trace(err);
             return done(err);
         }
 
-        // Returned when successful.
-        if (data.indexOf('The document validates') > -1) {
+        // Return when successful.
+        if (data.includes('The document validates')) {
             return done();
         }
 

--- a/test/test_helper.js
+++ b/test/test_helper.js
@@ -97,36 +97,18 @@ function assertValidHTML(res, done) {
     validator(options, (err, data) => {
         if (err) {
             console.trace(err);
+            return done(err);
         }
 
-        const errors = data.split('\n')
-            .filter((e) => {
-                if (e.startsWith('Error:')) {
-                    return true;
-                }
-                return false;
-            })
-            .filter((e) => {
-                const ignores = [];
-
-                for (let i = 0, len = ignores.length; i < len; i++) {
-                    if (e.match(ignores[i])) {
-                        console.log(`\n>> (IGNORED) ${e}`);
-                        return false;
-                    }
-                }
-                console.error(`\n>> ${e}\n`);
-                return true;
-            });
-
-        if (errors.length > 0) {
-            const sep = '\n\t - ';
-
-            assert(false, sep + errors.join(sep));
-        } else {
-            assert(true);
+        // Returned when successful.
+        if (data.indexOf('The document validates') > -1) {
+            return done();
         }
-        done();
+
+        // Formatting output for readability.
+        const errStr = `HTML Validation for '${res.request.path}' failed with:\n\t${data.replace('Error: ', '').split('\n').join('\n\t')}\n`;
+
+        return done(new Error(errStr));
     });
 }
 


### PR DESCRIPTION
@XhmikosR Cleaned up the `assertValidHTML` method a bit. Created this PR on to your branch to you can just pull it in -- or close this and cherry-pick the commit if you prefer.

Example output with a forced error:
```
  1) valid html:
     Error: HTML Validation for '/' failed with:
        The “center” element is obsolete. Use CSS instead.
        From line 224, column 11; to line 224, column 18
        There were errors.
```

RE `--exit`. I remember adding that, but I wasn't able to reproduce the condition which caused mocha to hang. And insights on that would be helpful.