### PR TITLE
Add tests for redirects.

### DIFF
--- a/test/redirects_test.js
+++ b/test/redirects_test.js
@@ -1,0 +1,37 @@
+'use strict';
+
+const assert = require('assert');
+const helpers = require('./test_helpers.js');
+
+const config = helpers.getConfig();
+
+describe('redirects', () => {
+    const redirects = {
+        '/legacy/': '/legacy/bootstrap/',
+        '/alpha/': '/',
+        '/beta/': '/'
+    };
+
+    for (const redirectFrom in redirects) {
+        if (Object.prototype.hasOwnProperty.call(redirects, redirectFrom)) {
+            const redirectTo = redirects[redirectFrom];
+            let uri = '';
+            let response = {};
+
+            before((done) => {
+                uri = helpers.runApp(config, redirectFrom);
+
+                helpers.preFetch(uri, (res) => {
+                    response = res;
+                    done();
+                });
+            });
+
+            it(`"${redirectFrom}" redirects to "${redirectTo}"`, (done) => {
+                assert.strictEqual(response.statusCode, 301);
+                assert.strictEqual(response.headers.location, redirectTo);
+                done();
+            });
+        }
+    }
+});

--- a/test/test_helpers.js
+++ b/test/test_helpers.js
@@ -134,6 +134,7 @@ function preFetch(uri, cb) {
     const reqOpts = {
         uri,
         forever: true, // for 'connection: Keep-Alive'
+        followRedirect: false,
         gzip: true
     };
 


### PR DESCRIPTION
@jmervine: The problem with this approach is that I'm not sure how to access the original request to test for a `301` response status code and for the target uri.

The only thing I've found so far is the `response`'s object which contains this bit we might be able to use:

```js
IncomingMessage: {
    request: {
        Request: {
             headers: {
                referer: 'http://localhost:3334/legacy/'
            }
        }
    }
}
```

Fixes #1045.