### PR TITLE
Handle theme's query edge case

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -13,7 +13,9 @@ function sriDigest(file, fromString) {
 }
 
 function selectedTheme(config, selected) {
-    if (typeof selected === 'undefined') {
+    const themes = config.bootswatch4.themes;
+
+    if (typeof selected === 'undefined' || selected >= themes.length) {
         return config.theme;
     }
 

--- a/routes/index.js
+++ b/routes/index.js
@@ -7,6 +7,7 @@ const digest = helpers.sri.digest;
 const SRI_CACHE = {};
 
 function appendLocals(req, res) {
+    const totalThemes = helpers.getConfig().bootswatch4.themes.length;
     const TITLE_SUFFIX = 'BootstrapCDN by StackPath';
     let proto = req.get('x-forwarded-proto');
 
@@ -18,7 +19,9 @@ function appendLocals(req, res) {
 
     res.locals.siteUrl = `${proto}://${req.hostname}`;
 
-    res.locals.theme = req.query.theme;
+    res.locals.theme = req.query.theme < totalThemes ?
+        req.query.theme :
+        '';
 
     res.locals.displayTitle = (title) => `${title} · ${TITLE_SUFFIX}`;
 


### PR DESCRIPTION
@jmervine: I'm not sure I love this approach, but it does seem to do the job, i.e. no `TypeError` is thrown, thus no Error 500 on production.

If you have suggestions how to tackle this please let me know or push here.

Fixes #1090 