### PR TITLE
Move `before` hook inside describe.

### DIFF
--- a/test/404_test.js
+++ b/test/404_test.js
@@ -8,14 +8,14 @@ const uri       = helpers.runApp(config, '404');
 
 let response    = {};
 
-before((done) => {
-    helpers.preFetch(uri, (res) => {
-        response = res;
-        done();
-    });
-});
-
 describe('404', () => {
+    before((done) => {
+        helpers.preFetch(uri, (res) => {
+            response = res;
+            done();
+        });
+    });
+
     it('works', (done) => {
         assert.strictEqual(response.statusCode, 404);
         done();

--- a/test/about_test.js
+++ b/test/about_test.js
@@ -7,14 +7,14 @@ const uri       = helpers.runApp(config, 'about');
 
 let response    = {};
 
-before((done) => {
-    helpers.preFetch(uri, (res) => {
-        response = res;
-        done();
-    });
-});
-
 describe('About', () => {
+    before((done) => {
+        helpers.preFetch(uri, (res) => {
+            response = res;
+            done();
+        });
+    });
+
     it('works', (done) => {
         helpers.assert.itWorks(response.statusCode, done);
     });

--- a/test/bootlint_test.js
+++ b/test/bootlint_test.js
@@ -8,14 +8,14 @@ const uri       = helpers.runApp(config, 'bootlint');
 
 let response    = {};
 
-before((done) => {
-    helpers.preFetch(uri, (res) => {
-        response = res;
-        done();
-    });
-});
-
 describe('bootlint', () => {
+    before((done) => {
+        helpers.preFetch(uri, (res) => {
+            response = res;
+            done();
+        });
+    });
+
     it('works', (done) => {
         helpers.assert.itWorks(response.statusCode, done);
     });

--- a/test/bootstrap_legacy_test.js
+++ b/test/bootstrap_legacy_test.js
@@ -8,14 +8,14 @@ const uri       = helpers.runApp(config, 'legacy/bootstrap');
 
 let response    = {};
 
-before((done) => {
-    helpers.preFetch(uri, (res) => {
-        response = res;
-        done();
-    });
-});
-
 describe('legacy/bootstrap', () => {
+    before((done) => {
+        helpers.preFetch(uri, (res) => {
+            response = res;
+            done();
+        });
+    });
+
     it('works', (done) => {
         helpers.assert.itWorks(response.statusCode, done);
     });

--- a/test/bootswatch3_test.js
+++ b/test/bootswatch3_test.js
@@ -13,14 +13,14 @@ function format(str, name) {
                 .replace('SWATCH_VERSION', config.bootswatch3.version);
 }
 
-before((done) => {
-    helpers.preFetch(uri, (res) => {
-        response = res;
-        done();
-    });
-});
-
 describe('bootswatch3', () => {
+    before((done) => {
+        helpers.preFetch(uri, (res) => {
+            response = res;
+            done();
+        });
+    });
+
     it('works', (done) => {
         helpers.assert.itWorks(response.statusCode, done);
     });

--- a/test/bootswatch4_test.js
+++ b/test/bootswatch4_test.js
@@ -13,14 +13,14 @@ function format(str, name) {
                 .replace('SWATCH_VERSION', config.bootswatch4.version);
 }
 
-before((done) => {
-    helpers.preFetch(uri, (res) => {
-        response = res;
-        done();
-    });
-});
-
 describe('bootswatch4', () => {
+    before((done) => {
+        helpers.preFetch(uri, (res) => {
+            response = res;
+            done();
+        });
+    });
+
     it('works', (done) => {
         helpers.assert.itWorks(response.statusCode, done);
     });

--- a/test/data_test.js
+++ b/test/data_test.js
@@ -9,14 +9,14 @@ const uri       = helpers.runApp(config, 'data/bootstrapcdn.json');
 
 let response    = {};
 
-before((done) => {
-    helpers.preFetch(uri, (res) => {
-        response = res;
-        done();
-    });
-});
-
 describe('data', () => {
+    before((done) => {
+        helpers.preFetch(uri, (res) => {
+            response = res;
+            done();
+        });
+    });
+
     it('/data/bootstrapcdn.json :: 200\'s', (done) => {
         helpers.assert.itWorks(response.statusCode, done);
     });

--- a/test/fontawesome_legacy_test.js
+++ b/test/fontawesome_legacy_test.js
@@ -8,14 +8,14 @@ const uri       = helpers.runApp(config, 'legacy/fontawesome');
 
 let response    = {};
 
-before((done) => {
-    helpers.preFetch(uri, (res) => {
-        response = res;
-        done();
-    });
-});
-
 describe('legacy/fontawesome', () => {
+    before((done) => {
+        helpers.preFetch(uri, (res) => {
+            response = res;
+            done();
+        });
+    });
+
     it('works', (done) => {
         helpers.assert.itWorks(response.statusCode, done);
     });

--- a/test/fontawesome_test.js
+++ b/test/fontawesome_test.js
@@ -8,14 +8,14 @@ const uri       = helpers.runApp(config, 'fontawesome');
 
 let response    = {};
 
-before((done) => {
-    helpers.preFetch(uri, (res) => {
-        response = res;
-        done();
-    });
-});
-
 describe('fontawesome', () => {
+    before((done) => {
+        helpers.preFetch(uri, (res) => {
+            response = res;
+            done();
+        });
+    });
+
     it('works', (done) => {
         helpers.assert.itWorks(response.statusCode, done);
     });

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -8,14 +8,14 @@ const uri       = helpers.runApp(config);
 
 let response    = {};
 
-before((done) => {
-    helpers.preFetch(uri, (res) => {
-        response = res;
-        done();
-    });
-});
-
 describe('index', () => {
+    before((done) => {
+        helpers.preFetch(uri, (res) => {
+            response = res;
+            done();
+        });
+    });
+
     it('works', (done) => {
         helpers.assert.itWorks(response.statusCode, done);
     });

--- a/test/integrations_test.js
+++ b/test/integrations_test.js
@@ -10,14 +10,14 @@ const uri        = helpers.runApp(config, 'integrations');
 
 let response = {};
 
-before((done) => {
-    helpers.preFetch(uri, (res) => {
-        response = res;
-        done();
-    });
-});
-
 describe('integrations', () => {
+    before((done) => {
+        helpers.preFetch(uri, (res) => {
+            response = res;
+            done();
+        });
+    });
+
     it('works', (done) => {
         helpers.assert.itWorks(response.statusCode, done);
     });

--- a/test/privacy_policy_test.js
+++ b/test/privacy_policy_test.js
@@ -7,14 +7,14 @@ const uri       = helpers.runApp(config, 'privacy-policy');
 
 let response = {};
 
-before((done) => {
-    helpers.preFetch(uri, (res) => {
-        response = res;
-        done();
-    });
-});
-
 describe('privacy-policy', () => {
+    before((done) => {
+        helpers.preFetch(uri, (res) => {
+            response = res;
+            done();
+        });
+    });
+
     it('works', (done) => {
         helpers.assert.itWorks(response.statusCode, done);
     });

--- a/test/robots_test.js
+++ b/test/robots_test.js
@@ -8,14 +8,14 @@ const uri       = helpers.runApp(config, 'robots.txt');
 
 let response    = {};
 
-before((done) => {
-    helpers.preFetch(uri, (res) => {
-        response = res;
-        done();
-    });
-});
-
 describe('robots.txt', () => {
+    before((done) => {
+        helpers.preFetch(uri, (res) => {
+            response = res;
+            done();
+        });
+    });
+
     it('works', (done) => {
         helpers.assert.itWorks(response.statusCode, done);
     });

--- a/test/showcase_test.js
+++ b/test/showcase_test.js
@@ -10,14 +10,14 @@ const uri        = helpers.runApp(config, 'showcase');
 
 let response = {};
 
-before((done) => {
-    helpers.preFetch(uri, (res) => {
-        response = res;
-        done();
-    });
-});
-
 describe('showcase', () => {
+    before((done) => {
+        helpers.preFetch(uri, (res) => {
+            response = res;
+            done();
+        });
+    });
+
     it('works', (done) => {
         helpers.assert.itWorks(response.statusCode, done);
     });

--- a/test/sitemap_test.js
+++ b/test/sitemap_test.js
@@ -7,14 +7,14 @@ const uri       = helpers.runApp(config, 'sitemap.xml');
 
 let response    = {};
 
-before((done) => {
-    helpers.preFetch(uri, (res) => {
-        response = res;
-        done();
-    });
-});
-
 describe('sitemap.xml', () => {
+    before((done) => {
+        helpers.preFetch(uri, (res) => {
+            response = res;
+            done();
+        });
+    });
+
     it('works', (done) => {
         helpers.assert.itWorks(response.statusCode, done);
     });


### PR DESCRIPTION
The `before` hooks in a file, which are not in a describe block, get executed before any tests are run in said file.

I don't think this was intended.