### PR TITLE
Clean up tests more.

### DIFF
--- a/test/404_test.js
+++ b/test/404_test.js
@@ -1,16 +1,14 @@
 'use strict';
 
-const assert    = require('assert');
-const helpers   = require('./test_helpers.js');
-
-const config    = helpers.getConfig();
-const uri       = helpers.runApp(config, '404');
-
-let response    = {};
+const assert = require('assert').strict;
+const helpers = require('./test_helpers.js');
 
 describe('404', () => {
+    const uri = helpers.runApp('404');
+    let response = {};
+
     before((done) => {
-        helpers.preFetch(uri, (res) => {
+        helpers.prefetch(uri, (res) => {
             response = res;
             done();
         });

--- a/test/about_test.js
+++ b/test/about_test.js
@@ -1,15 +1,13 @@
 'use strict';
 
-const helpers   = require('./test_helpers.js');
-
-const config    = helpers.getConfig();
-const uri       = helpers.runApp(config, 'about');
-
-let response    = {};
+const helpers = require('./test_helpers.js');
 
 describe('About', () => {
+    const uri = helpers.runApp('about');
+    let response = {};
+
     before((done) => {
-        helpers.preFetch(uri, (res) => {
+        helpers.prefetch(uri, (res) => {
             response = res;
             done();
         });

--- a/test/bootlint_test.js
+++ b/test/bootlint_test.js
@@ -1,16 +1,16 @@
 'use strict';
 
-const assert    = require('assert');
-const helpers   = require('./test_helpers.js');
-
-const config    = helpers.getConfig();
-const uri       = helpers.runApp(config, 'bootlint');
-
-let response    = {};
+const assert = require('assert').strict;
+const helpers = require('./test_helpers.js');
 
 describe('bootlint', () => {
+    const config = helpers.getConfig();
+    const uri = helpers.runApp('bootlint');
+    const current = config.bootlint[0];
+    let response = {};
+
     before((done) => {
-        helpers.preFetch(uri, (res) => {
+        helpers.prefetch(uri, (res) => {
             response = res;
             done();
         });
@@ -19,8 +19,6 @@ describe('bootlint', () => {
     it('works', (done) => {
         helpers.assert.itWorks(response.statusCode, done);
     });
-
-    const current = config.bootlint[0];
 
     it('is current', (done) => {
         assert.ok(current.current);

--- a/test/bootstrap_legacy_test.js
+++ b/test/bootstrap_legacy_test.js
@@ -1,16 +1,15 @@
 'use strict';
 
-const assert    = require('assert');
-const helpers   = require('./test_helpers.js');
-
-const config    = helpers.getConfig();
-const uri       = helpers.runApp(config, 'legacy/bootstrap');
-
-let response    = {};
+const assert = require('assert').strict;
+const helpers = require('./test_helpers.js');
 
 describe('legacy/bootstrap', () => {
+    const config = helpers.getConfig();
+    const uri = helpers.runApp('legacy/bootstrap');
+    let response = {};
+
     before((done) => {
-        helpers.preFetch(uri, (res) => {
+        helpers.prefetch(uri, (res) => {
             response = res;
             done();
         });

--- a/test/bootswatch3_test.js
+++ b/test/bootswatch3_test.js
@@ -1,12 +1,9 @@
 'use strict';
 
-const assert    = require('assert');
-const helpers   = require('./test_helpers.js');
+const assert = require('assert').strict;
+const helpers = require('./test_helpers.js');
 
-const config    = helpers.getConfig();
-const uri       = helpers.runApp(config, 'legacy/bootswatch');
-
-let response    = {};
+const config = helpers.getConfig();
 
 function format(str, name) {
     return str.replace('SWATCH_NAME', name)
@@ -14,8 +11,11 @@ function format(str, name) {
 }
 
 describe('bootswatch3', () => {
+    const uri = helpers.runApp('legacy/bootswatch');
+    let response = {};
+
     before((done) => {
-        helpers.preFetch(uri, (res) => {
+        helpers.prefetch(uri, (res) => {
             response = res;
             done();
         });
@@ -37,11 +37,11 @@ describe('bootswatch3', () => {
         helpers.assert.pageHeader('Bootswatch 3', response, done);
     });
     config.bootswatch3.themes.forEach((theme) => {
-        const themeImage = format(config.bootswatch3.image, theme.name);
-        const themeUri   = format(config.bootswatch3.bootstrap, theme.name);
-        const themeSri   = theme.sri;
-
         describe(theme.name, () => {
+            const themeImage = format(config.bootswatch3.image, theme.name);
+            const themeUri = format(config.bootswatch3.bootstrap, theme.name);
+            const themeSri = theme.sri;
+
             it('has image', (done) => {
                 assert.ok(response.body.includes(themeImage), `Expects response body to include "${themeImage}"`);
                 done();

--- a/test/bootswatch4_test.js
+++ b/test/bootswatch4_test.js
@@ -1,12 +1,9 @@
 'use strict';
 
-const assert    = require('assert');
-const helpers   = require('./test_helpers.js');
+const assert = require('assert').strict;
+const helpers = require('./test_helpers.js');
 
-const config    = helpers.getConfig();
-const uri       = helpers.runApp(config, 'bootswatch');
-
-let response    = {};
+const config = helpers.getConfig();
 
 function format(str, name) {
     return str.replace('SWATCH_NAME', name)
@@ -14,8 +11,11 @@ function format(str, name) {
 }
 
 describe('bootswatch4', () => {
+    const uri = helpers.runApp('bootswatch');
+    let response = {};
+
     before((done) => {
-        helpers.preFetch(uri, (res) => {
+        helpers.prefetch(uri, (res) => {
             response = res;
             done();
         });
@@ -38,11 +38,11 @@ describe('bootswatch4', () => {
     });
 
     config.bootswatch4.themes.forEach((theme) => {
-        const themeImage = format(config.bootswatch4.image, theme.name);
-        const themeUri   = format(config.bootswatch4.bootstrap, theme.name);
-        const themeSri   = theme.sri;
-
         describe(theme.name, () => {
+            const themeImage = format(config.bootswatch4.image, theme.name);
+            const themeUri   = format(config.bootswatch4.bootstrap, theme.name);
+            const themeSri   = theme.sri;
+
             it('has image', (done) => {
                 assert.ok(response.body.includes(themeImage),
                     `Expects response body to include "${themeImage}"`);

--- a/test/data_test.js
+++ b/test/data_test.js
@@ -1,23 +1,21 @@
 'use strict';
 
-const assert    = require('assert');
+const assert = require('assert').strict;
 const libHelpers = require('../lib/helpers.js');
-const helpers   = require('./test_helpers.js');
-
-const config    = helpers.getConfig();
-const uri       = helpers.runApp(config, 'data/bootstrapcdn.json');
-
-let response    = {};
+const helpers = require('./test_helpers.js');
 
 describe('data', () => {
+    const uri = helpers.runApp('data/bootstrapcdn.json');
+    let response = {};
+
     before((done) => {
-        helpers.preFetch(uri, (res) => {
+        helpers.prefetch(uri, (res) => {
             response = res;
             done();
         });
     });
 
-    it('/data/bootstrapcdn.json :: 200\'s', (done) => {
+    it('works', (done) => {
         helpers.assert.itWorks(response.statusCode, done);
     });
 

--- a/test/fontawesome_legacy_test.js
+++ b/test/fontawesome_legacy_test.js
@@ -1,16 +1,15 @@
 'use strict';
 
-const assert    = require('assert');
-const helpers   = require('./test_helpers.js');
-
-const config    = helpers.getConfig();
-const uri       = helpers.runApp(config, 'legacy/fontawesome');
-
-let response    = {};
+const assert = require('assert').strict;
+const helpers = require('./test_helpers.js');
 
 describe('legacy/fontawesome', () => {
+    const config = helpers.getConfig();
+    const uri = helpers.runApp('legacy/fontawesome');
+    let response = {};
+
     before((done) => {
-        helpers.preFetch(uri, (res) => {
+        helpers.prefetch(uri, (res) => {
             response = res;
             done();
         });

--- a/test/fontawesome_test.js
+++ b/test/fontawesome_test.js
@@ -1,16 +1,16 @@
 'use strict';
 
-const assert    = require('assert');
-const helpers   = require('./test_helpers.js');
-
-const config    = helpers.getConfig();
-const uri       = helpers.runApp(config, 'fontawesome');
-
-let response    = {};
+const assert = require('assert').strict;
+const helpers = require('./test_helpers.js');
 
 describe('fontawesome', () => {
+    const config = helpers.getConfig();
+    const uri = helpers.runApp('fontawesome');
+    const current = config.fontawesome[0];
+    let response = {};
+
     before((done) => {
-        helpers.preFetch(uri, (res) => {
+        helpers.prefetch(uri, (res) => {
             response = res;
             done();
         });
@@ -19,8 +19,6 @@ describe('fontawesome', () => {
     it('works', (done) => {
         helpers.assert.itWorks(response.statusCode, done);
     });
-
-    const current = config.fontawesome[0];
 
     it('is current', (done) => {
         assert.ok(current.current);

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -1,16 +1,16 @@
 'use strict';
 
-const assert    = require('assert');
-const helpers   = require('./test_helpers.js');
-
-const config    = helpers.getConfig();
-const uri       = helpers.runApp(config);
-
-let response    = {};
+const assert = require('assert').strict;
+const helpers = require('./test_helpers.js');
 
 describe('index', () => {
+    const config = helpers.getConfig();
+    const uri = helpers.runApp();
+    const current = config.bootstrap[0];
+    let response = {};
+
     before((done) => {
-        helpers.preFetch(uri, (res) => {
+        helpers.prefetch(uri, (res) => {
             response = res;
             done();
         });
@@ -19,8 +19,6 @@ describe('index', () => {
     it('works', (done) => {
         helpers.assert.itWorks(response.statusCode, done);
     });
-
-    const current = config.bootstrap[0];
 
     it('is current', (done) => {
         assert.ok(current.current);

--- a/test/integrations_test.js
+++ b/test/integrations_test.js
@@ -1,18 +1,17 @@
 'use strict';
 
-const assert     = require('assert');
-const path       = require('path');
-const staticify  = require('staticify')(path.join(__dirname, '../public'));
-const helpers    = require('./test_helpers.js');
-
-const config     = helpers.getConfig();
-const uri        = helpers.runApp(config, 'integrations');
-
-let response = {};
+const assert = require('assert').strict;
+const path = require('path');
+const staticify = require('staticify')(path.join(__dirname, '../public'));
+const helpers = require('./test_helpers.js');
 
 describe('integrations', () => {
+    const config = helpers.getConfig();
+    const uri = helpers.runApp('integrations');
+    let response = {};
+
     before((done) => {
-        helpers.preFetch(uri, (res) => {
+        helpers.prefetch(uri, (res) => {
             response = res;
             done();
         });

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -2,7 +2,6 @@
 --exit
 --globals __core-js_shared__
 --reporter dot
---retries 1
 --slow 500
 --throw-deprecation
 --timeout 15000

--- a/test/privacy_policy_test.js
+++ b/test/privacy_policy_test.js
@@ -1,15 +1,13 @@
 'use strict';
 
-const helpers   = require('./test_helpers.js');
-
-const config    = helpers.getConfig();
-const uri       = helpers.runApp(config, 'privacy-policy');
-
-let response = {};
+const helpers = require('./test_helpers.js');
 
 describe('privacy-policy', () => {
+    const uri = helpers.runApp('privacy-policy');
+    let response = {};
+
     before((done) => {
-        helpers.preFetch(uri, (res) => {
+        helpers.prefetch(uri, (res) => {
             response = res;
             done();
         });

--- a/test/redirects_test.js
+++ b/test/redirects_test.js
@@ -1,12 +1,12 @@
 'use strict';
 
-const assert = require('assert');
+const assert = require('assert').strict;
 const helpers = require('./test_helpers.js');
 
-const config = helpers.getConfig();
-const redirects = config.redirects;
-
 describe('redirects', () => {
+    const config = helpers.getConfig();
+    const redirects = config.redirects;
+
     for (const redirect in redirects) {
         if (Object.prototype.hasOwnProperty.call(redirects, redirect)) {
             const redirectFrom = redirects[redirect].from;
@@ -15,9 +15,9 @@ describe('redirects', () => {
             let response = {};
 
             before((done) => {
-                uri = helpers.runApp(config, redirectFrom);
+                uri = helpers.runApp(redirectFrom);
 
-                helpers.preFetch(uri, (res) => {
+                helpers.prefetch(uri, (res) => {
                     response = res;
                     done();
                 });

--- a/test/robots_test.js
+++ b/test/robots_test.js
@@ -1,16 +1,14 @@
 'use strict';
 
-const assert    = require('assert');
-const helpers   = require('./test_helpers.js');
-
-const config    = helpers.getConfig();
-const uri       = helpers.runApp(config, 'robots.txt');
-
-let response    = {};
+const assert = require('assert').strict;
+const helpers = require('./test_helpers.js');
 
 describe('robots.txt', () => {
+    const uri = helpers.runApp('robots.txt');
+    let response = {};
+
     before((done) => {
-        helpers.preFetch(uri, (res) => {
+        helpers.prefetch(uri, (res) => {
             response = res;
             done();
         });

--- a/test/showcase_test.js
+++ b/test/showcase_test.js
@@ -1,18 +1,17 @@
 'use strict';
 
-const assert     = require('assert');
-const path       = require('path');
-const staticify  = require('staticify')(path.join(__dirname, '../public'));
-const helpers    = require('./test_helpers.js');
-
-const config     = helpers.getConfig();
-const uri        = helpers.runApp(config, 'showcase');
-
-let response = {};
+const assert = require('assert').strict;
+const path = require('path');
+const staticify = require('staticify')(path.join(__dirname, '../public'));
+const helpers = require('./test_helpers.js');
 
 describe('showcase', () => {
+    const config = helpers.getConfig();
+    const uri = helpers.runApp('showcase');
+    let response = {};
+
     before((done) => {
-        helpers.preFetch(uri, (res) => {
+        helpers.prefetch(uri, (res) => {
             response = res;
             done();
         });

--- a/test/sitemap_test.js
+++ b/test/sitemap_test.js
@@ -1,15 +1,13 @@
 'use strict';
 
-const helpers   = require('./test_helpers.js');
-
-const config    = helpers.getConfig();
-const uri       = helpers.runApp(config, 'sitemap.xml');
-
-let response    = {};
+const helpers = require('./test_helpers.js');
 
 describe('sitemap.xml', () => {
+    const uri = helpers.runApp('sitemap.xml');
+    let response = {};
+
     before((done) => {
-        helpers.preFetch(uri, (res) => {
+        helpers.prefetch(uri, (res) => {
             response = res;
             done();
         });


### PR DESCRIPTION
* Reduce the number of variables we are passing around in tests
* Move variables in the block they are used
* Use `assert`'s strict mode
* Add back a try/catch block in `assert.itWorks` to fix the uncaught assertion error
* Remove unneeded global variable `responses` in test_helpers.js
* Move `domainCheck` in functional since it's only used there
* Remove unused parameter and code from `assertHeaders`
* Rename `preFetch` to `prefetch`
* Remove mocha's retries again; tests should not fail
