### PR TITLE
Fixes the tests hang with mocha.

### DIFF
--- a/test/404_test.js
+++ b/test/404_test.js
@@ -4,10 +4,11 @@ const assert = require('assert').strict;
 const helpers = require('./test_helpers.js');
 
 describe('404', () => {
-    const uri = helpers.runApp('404');
+    const uri = helpers.getURI('404');
     let response = {};
 
     before((done) => {
+        helpers.startServer();
         helpers.prefetch(uri, (res) => {
             response = res;
             done();

--- a/test/about_test.js
+++ b/test/about_test.js
@@ -3,7 +3,7 @@
 const helpers = require('./test_helpers.js');
 
 describe('About', () => {
-    const uri = helpers.runApp('about');
+    const uri = helpers.getURI('about');
     let response = {};
 
     before((done) => {

--- a/test/bootlint_test.js
+++ b/test/bootlint_test.js
@@ -5,7 +5,7 @@ const helpers = require('./test_helpers.js');
 
 describe('bootlint', () => {
     const config = helpers.getConfig();
-    const uri = helpers.runApp('bootlint');
+    const uri = helpers.getURI('bootlint');
     const current = config.bootlint[0];
     let response = {};
 

--- a/test/bootstrap_legacy_test.js
+++ b/test/bootstrap_legacy_test.js
@@ -5,7 +5,7 @@ const helpers = require('./test_helpers.js');
 
 describe('legacy/bootstrap', () => {
     const config = helpers.getConfig();
-    const uri = helpers.runApp('legacy/bootstrap');
+    const uri = helpers.getURI('legacy/bootstrap');
     let response = {};
 
     before((done) => {

--- a/test/bootswatch3_test.js
+++ b/test/bootswatch3_test.js
@@ -11,7 +11,7 @@ function format(str, name) {
 }
 
 describe('bootswatch3', () => {
-    const uri = helpers.runApp('legacy/bootswatch');
+    const uri = helpers.getURI('legacy/bootswatch');
     let response = {};
 
     before((done) => {

--- a/test/bootswatch4_test.js
+++ b/test/bootswatch4_test.js
@@ -11,7 +11,7 @@ function format(str, name) {
 }
 
 describe('bootswatch4', () => {
-    const uri = helpers.runApp('bootswatch');
+    const uri = helpers.getURI('bootswatch');
     let response = {};
 
     before((done) => {

--- a/test/data_test.js
+++ b/test/data_test.js
@@ -5,7 +5,7 @@ const libHelpers = require('../lib/helpers.js');
 const helpers = require('./test_helpers.js');
 
 describe('data', () => {
-    const uri = helpers.runApp('data/bootstrapcdn.json');
+    const uri = helpers.getURI('data/bootstrapcdn.json');
     let response = {};
 
     before((done) => {

--- a/test/fontawesome_legacy_test.js
+++ b/test/fontawesome_legacy_test.js
@@ -5,7 +5,7 @@ const helpers = require('./test_helpers.js');
 
 describe('legacy/fontawesome', () => {
     const config = helpers.getConfig();
-    const uri = helpers.runApp('legacy/fontawesome');
+    const uri = helpers.getURI('legacy/fontawesome');
     let response = {};
 
     before((done) => {

--- a/test/fontawesome_test.js
+++ b/test/fontawesome_test.js
@@ -5,7 +5,7 @@ const helpers = require('./test_helpers.js');
 
 describe('fontawesome', () => {
     const config = helpers.getConfig();
-    const uri = helpers.runApp('fontawesome');
+    const uri = helpers.getURI('fontawesome');
     const current = config.fontawesome[0];
     let response = {};
 

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -5,7 +5,7 @@ const helpers = require('./test_helpers.js');
 
 describe('index', () => {
     const config = helpers.getConfig();
-    const uri = helpers.runApp();
+    const uri = helpers.getURI();
     const current = config.bootstrap[0];
     let response = {};
 

--- a/test/integrations_test.js
+++ b/test/integrations_test.js
@@ -7,7 +7,7 @@ const helpers = require('./test_helpers.js');
 
 describe('integrations', () => {
     const config = helpers.getConfig();
-    const uri = helpers.runApp('integrations');
+    const uri = helpers.getURI('integrations');
     let response = {};
 
     before((done) => {

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,5 +1,4 @@
 --check-leaks
---exit
 --globals __core-js_shared__
 --reporter dot
 --slow 500

--- a/test/privacy_policy_test.js
+++ b/test/privacy_policy_test.js
@@ -3,7 +3,7 @@
 const helpers = require('./test_helpers.js');
 
 describe('privacy-policy', () => {
-    const uri = helpers.runApp('privacy-policy');
+    const uri = helpers.getURI('privacy-policy');
     let response = {};
 
     before((done) => {

--- a/test/redirects_test.js
+++ b/test/redirects_test.js
@@ -15,7 +15,7 @@ describe('redirects', () => {
             let response = {};
 
             before((done) => {
-                uri = helpers.runApp(redirectFrom);
+                uri = helpers.getURI(redirectFrom);
 
                 helpers.prefetch(uri, (res) => {
                     response = res;

--- a/test/robots_test.js
+++ b/test/robots_test.js
@@ -4,7 +4,7 @@ const assert = require('assert').strict;
 const helpers = require('./test_helpers.js');
 
 describe('robots.txt', () => {
-    const uri = helpers.runApp('robots.txt');
+    const uri = helpers.getURI('robots.txt');
     let response = {};
 
     before((done) => {

--- a/test/showcase_test.js
+++ b/test/showcase_test.js
@@ -7,7 +7,7 @@ const helpers = require('./test_helpers.js');
 
 describe('showcase', () => {
     const config = helpers.getConfig();
-    const uri = helpers.runApp('showcase');
+    const uri = helpers.getURI('showcase');
     let response = {};
 
     before((done) => {

--- a/test/sitemap_test.js
+++ b/test/sitemap_test.js
@@ -3,7 +3,7 @@
 const helpers = require('./test_helpers.js');
 
 describe('sitemap.xml', () => {
-    const uri = helpers.runApp('sitemap.xml');
+    const uri = helpers.getURI('sitemap.xml');
     let response = {};
 
     before((done) => {
@@ -11,6 +11,10 @@ describe('sitemap.xml', () => {
             response = res;
             done();
         });
+    });
+
+    after((done) => {
+        helpers.stopServer(done);
     });
 
     it('works', (done) => {


### PR DESCRIPTION
We basically start the server in the first test file and close it in the last.

When starting the server, it won't break anything if we start it in the other tests too. I can remove this code and make the patch shorter.

Unfortunately, I tried starting and closing the server in each test and that was 3x slower.

So, to sum it up, I can remove the logic of a global server object in test_helper if we are sure to only start it in the first test.

Fixes #1027.