### PR TITLE
Load Bootswatch from npm too.

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,13 +79,18 @@ Contains the CDN files we host.The SRI values are updated by running `npm run in
 
 Our CSP config using <https://github.com/helmetjs/csp>
 
-## Updating Bootstrap/Bootlint
+## Updating Bootstrap/Bootlint/Bootswatch
 
-1. `npm i bootstrap@version --save-exact -D`/`npm i bootlint@version --save-exact -D`
-2. `npm run bootstrap version`/`npm run bootlint version`
-3. Update `config/_config.yml` accordingly
-4. `npm run integrity`
-5. Make sure `npm run ci` passes after the files are on S3/CDN and verify the frontend works as expected without any visual breakage
+Replace `package` by the package you want to update and `version` with its version in the following commands:
+
+```shell
+npm i package@version --save-exact -D
+npm run package version
+```
+
+1. Update `config/_config.yml` accordingly
+2. `npm run integrity`
+3. Make sure `npm run ci` passes after the files are on S3/CDN and verify the frontend works as expected without any visual breakage
 
 ## Backers
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -589,6 +589,15 @@
       "integrity": "sha512-SpiDSOcbg4J/PjVSt4ny5eY6j74VbVSjROY4Fb/WIUXBV9cnb5luyR4KnPvNoXuGnBK1T+nJIWqRsvU3yP8Mcg==",
       "dev": true
     },
+    "bootswatch": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/bootswatch/-/bootswatch-4.1.1.tgz",
+      "integrity": "sha1-604FPEadTcjNr/Ef9N2+9j6GpW0=",
+      "dev": true,
+      "requires": {
+        "bootstrap": "^4.1.1"
+      }
+    },
     "boxen": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
   "devDependencies": {
     "bootlint": "0.14.2",
     "bootstrap": "4.1.1",
+    "bootswatch": "4.1.1",
     "coveralls": "^3.0.1",
     "eslint": "^4.19.1",
     "fs-extra": "^6.0.1",

--- a/scripts/update_bootstrap.js
+++ b/scripts/update_bootstrap.js
@@ -34,5 +34,5 @@ try {
     console.log(`Successfully copied "${bootstrapSrcDir}" to "${bootstrapDistDir}"`);
     console.log(`\nDo not forget to update "${path.normalize('config/_config.yml')}"!`);
 } catch (err) {
-    console.log(err);
+    throw new Error(err);
 }

--- a/scripts/update_bootswatch.js
+++ b/scripts/update_bootswatch.js
@@ -1,98 +1,48 @@
 #!/usr/bin/env node
 
-const fs      = require('fs');
-const path    = require('path');
-const request = require('request');
-const config  = require('../config');
+const fs = require('fs');
+const path = require('path');
+const fse = require('fs-extra');
+const walk = require('fs-walk');
 
-const version  = process.argv[2];
-const verMajor = version[0];
+let version = process.argv[2];
 
 if (!version) {
     console.log('Please pass the Bootswatch version as an argument.');
     process.exit(1);
 }
 
-const bootswatchDir = path.join(__dirname, '../cdn/bootswatch', version);
+// strip leading 'v' if present
+version = version.replace(/^v/, '');
 
-const files = [
-    'https://bootswatch.com/%d/%s/bootstrap.min.css',
-    'https://bootswatch.com/%d/%s/bootstrap.css'
-];
+const basedir = path.join(__dirname, '..');
+const bootswatchSrcDir = path.join(basedir, 'node_modules/bootswatch/dist');
+const bootswatchDistDir = path.join(basedir, 'cdn/bootswatch', version);
 
-const fonts    = 'https://bootswatch.com/3/fonts/%s';
-const fontsDir = path.join(bootswatchDir, 'fonts');
-
-function errorCheck(err) {
-    if (err) {
-        console.trace(err);
-        process.exit(1);
-    }
+if (fs.existsSync(bootswatchDistDir)) {
+    console.log('Bootswatch version already found.');
+    process.exit(1);
 }
 
-function checkDirSync(dir) {
-    try {
-        fs.statSync(dir);
-    } catch (err) {
-        fs.mkdirSync(dir);
-        console.log('Created: %s', dir);
+fs.mkdirSync(bootswatchDistDir);
+
+walk.filesSync(bootswatchSrcDir, (base, filename) => {
+    if (filename.endsWith('.css')) {
+        const themefolder = path.basename(base);
+
+        fse.ensureDirSync(path.join(bootswatchDistDir, themefolder));
+
+        try {
+            fse.copySync(path.join(base, filename), path.join(bootswatchDistDir, themefolder, filename), {
+                overwrite: false,
+                errorOnExist: true,
+                preserveTimestamps: true
+            });
+            console.log(`Copied "${path.join(themefolder, filename)}" to "${path.join(bootswatchDistDir, themefolder, filename)}"`);
+        } catch (err) {
+            throw new Error(err);
+        }
     }
-}
-
-checkDirSync(bootswatchDir);
-
-const bootswatchConf = config[`bootswatch${verMajor}`];
-
-files.forEach((file) => {
-    bootswatchConf.themes.forEach((theme) => {
-        const source = file.replace('%s', theme.name).replace('%d', verMajor);
-
-        request.get(source, (err, res, body) => {
-            if (err) {
-                console.log(err);
-                process.exit(1);
-            }
-
-            if (res.statusCode !== 200) {
-                console.log(source, 'not found');
-                return;
-            }
-            const targetDir = path.join(bootswatchDir, theme.name);
-
-            checkDirSync(targetDir);
-
-            const target = path.join(targetDir, path.basename(file));
-
-            fs.writeFileSync(target, body);
-            console.log('  Saved: %s', target);
-            console.log('    From: %s', source);
-        });
-    });
 });
 
-if (verMajor === '3') {
-    checkDirSync(fontsDir);
-    ['glyphicons-halflings-regular.eot',
-        'glyphicons-halflings-regular.svg',
-        'glyphicons-halflings-regular.ttf',
-        'glyphicons-halflings-regular.woff',
-        'glyphicons-halflings-regular.woff2'
-    ].forEach((font) => {
-        const fontPath = fonts.replace('%s', font);
-        const target   = path.join(fontsDir, font);
-
-        request
-            .get(fontPath)
-            .on('response', (res) => {
-                if (res.statusCode !== 200) {
-                    errorCheck(new Error(`Non-success status code: ${res.statusCode}`));
-                }
-                console.log('  Saved: %s', target);
-                console.log('    From: %s', fontPath);
-            })
-            .on('error', (err) => {
-                console.trace(err);
-            })
-            .pipe(fs.createWriteStream(target));
-    });
-}
+console.log(`\nDo not forget to update "${path.normalize('config/_config.yml')}"!`);


### PR DESCRIPTION
We might need to try another module since fs-extra doesn't seem to cover us here; exclude still copies all the files...

Any help is welcome.

Fixes #948.