### PR TITLE
Add Coveralls support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ node_js:
 
 script: npm run ci-with-coverage
 
+after_success:
+  - npm run coveralls
+
 matrix:
   fast_finish: true
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Follow BootstrapCDN on Twitter](https://img.shields.io/badge/twitter-@getBootstrapCDN-55acee.svg?style=flat-square)](https://twitter.com/getbootstrapcdn)
 [![Linux Build Status](https://img.shields.io/travis/MaxCDN/bootstrapcdn/develop.svg?label=Linux%20build&style=flat-square)](https://travis-ci.org/MaxCDN/bootstrapcdn)
 [![Windows Build status](https://img.shields.io/appveyor/ci/jdorfman/bootstrapcdn/develop.svg?label=Windows%20build&style=flat-square)](https://ci.appveyor.com/project/jdorfman/bootstrapcdn)
+[![Coverage Status](https://img.shields.io/coveralls/MaxCDN/bootstrapcdn.svg)](https://coveralls.io/github/MaxCDN/bootstrapcdn)
 [![dependencies Status](https://img.shields.io/david/MaxCDN/bootstrapcdn.svg?style=flat-square)](https://david-dm.org/MaxCDN/bootstrapcdn)
 [![devDependencies Status](https://img.shields.io/david/dev/MaxCDN/bootstrapcdn.svg?style=flat-square)](https://david-dm.org/MaxCDN/bootstrapcdn?type=dev)
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,7 +20,7 @@ build: off
 test_script:
   - node -v
   - npm -v
-  - npm run ci-with-coverage
+  - npm run ci
 
 matrix:
   fast_finish: true

--- a/config/_app.yml
+++ b/config/_app.yml
@@ -41,3 +41,6 @@ redirects:
   - name: beta
     from: /beta/
     to: /
+  - name: bootswatch4
+    from: /bootswatch4/
+    to: /bootswatch/

--- a/package-lock.json
+++ b/package-lock.json
@@ -948,6 +948,27 @@
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
+    "coveralls": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.0.1.tgz",
+      "integrity": "sha512-FAzXwiDOYLGDWH+zgoIA+8GbWv50hlx+kpEJyvzLKOdnIBv9uWoVl4DhqGgyUHpiRjAlF8KYZSipWXYtllWH6Q==",
+      "dev": true,
+      "requires": {
+        "js-yaml": "3.11.0",
+        "lcov-parse": "0.0.10",
+        "log-driver": "1.2.7",
+        "minimist": "1.2.0",
+        "request": "2.86.0"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
+    },
     "create-error-class": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
@@ -3286,6 +3307,12 @@
       "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
       "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4="
     },
+    "lcov-parse": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-0.0.10.tgz",
+      "integrity": "sha1-GwuP+ayceIklBYK3C3ExXZ2m2aM=",
+      "dev": true
+    },
     "levn": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
@@ -3305,6 +3332,12 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.reduce/-/lodash.reduce-4.6.0.tgz",
       "integrity": "sha1-8atrg5KZrUj3hKu/R2WW8DuRTTs="
+    },
+    "log-driver": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.7.tgz",
+      "integrity": "sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg==",
+      "dev": true
     },
     "longest": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "clean": "rm -rf ./node_modules/",
+    "coveralls": "nyc report --reporter=text-lcov | coveralls",
     "eslint": "eslint .",
     "puglint": "pug-lint views/",
     "pug-lint": "npm run puglint",
@@ -49,6 +50,7 @@
   "devDependencies": {
     "bootlint": "0.14.2",
     "bootstrap": "4.1.1",
+    "coveralls": "^3.0.1",
     "eslint": "^4.19.1",
     "fs-extra": "^6.0.1",
     "fs-walk": "^0.0.2",


### PR DESCRIPTION
Coveralls is added via OAUTH to my account.

The second commit is a live proof of code coverage :)

BTW I have set the limit to 85% but maybe we should set this is nyc.

Also, I don't know, do you guys have access to the Coveralls account? If not my guess is you'd need to login via GitHub, but I still don't know if you will have access to the Coveralls project settings. If not, it's a bummer, and generally I'm open to suggestions; I just went with Coveralls because I have used it in the past.

Fixes #1116 