### PR TITLE
Fix navbar's active class.

### DIFF
--- a/routes/appendLocals.js
+++ b/routes/appendLocals.js
@@ -19,6 +19,7 @@ function appendLocals(req, res) {
     res.locals.canonicalUrl = `${req.config.siteurl}${req.path}`;
 
     res.locals.siteUrl = `${proto}://${req.hostname}`;
+    res.locals.pageUrl = req.originalUrl;
 
     res.locals.theme = req.query.theme < totalThemes ?
         req.query.theme :

--- a/views/_mixins.pug
+++ b/views/_mixins.pug
@@ -6,7 +6,7 @@ mixin menuItem(name, url)
             classes.push(attributes['extra-class']);
         }
 
-        if (title === name) {
+        if (pageUrl === url) {
             classes.push('active');
         }
 


### PR DESCRIPTION
Use a new variable based on `req.originalUrl`.

This was visible in the Jobs page where the Page title != link title. Not sure if there's another "proper" way to do this.