### PR TITLE
tests: decrease mocha's timeout

### DIFF
--- a/test/404_test.js
+++ b/test/404_test.js
@@ -18,7 +18,8 @@ describe('404', () => {
         done();
     });
 
-    it('valid html', (done) => {
+    it('valid html', function(done) {
+        this.timeout(helpers.TESTS_TIMEOUT);
         helpers.assert.validHTML(response, done);
     });
 

--- a/test/about_test.js
+++ b/test/about_test.js
@@ -15,7 +15,8 @@ describe('About', () => {
         helpers.assert.itWorks(response.statusCode, done);
     });
 
-    it('valid html', (done) => {
+    it('valid html', function(done) {
+        this.timeout(helpers.TESTS_TIMEOUT);
         helpers.assert.validHTML(response, done);
     });
 

--- a/test/books_test.js
+++ b/test/books_test.js
@@ -20,7 +20,8 @@ describe('books', () => {
         helpers.assert.itWorks(response.statusCode, done);
     });
 
-    it('valid html', (done) => {
+    it('valid html', function(done) {
+        this.timeout(helpers.TESTS_TIMEOUT);
         helpers.assert.validHTML(response, done);
     });
 

--- a/test/bootlint_test.js
+++ b/test/bootlint_test.js
@@ -23,7 +23,8 @@ describe('bootlint', () => {
         done();
     });
 
-    it('valid html', (done) => {
+    it('valid html', function(done) {
+        this.timeout(helpers.TESTS_TIMEOUT);
         helpers.assert.validHTML(response, done);
     });
 

--- a/test/bootstrap_legacy_test.js
+++ b/test/bootstrap_legacy_test.js
@@ -17,7 +17,8 @@ describe('legacy/bootstrap', () => {
         helpers.assert.itWorks(response.statusCode, done);
     });
 
-    it('valid html', (done) => {
+    it('valid html', function(done) {
+        this.timeout(helpers.TESTS_TIMEOUT);
         helpers.assert.validHTML(response, done);
     });
 

--- a/test/bootswatch4_test.js
+++ b/test/bootswatch4_test.js
@@ -23,7 +23,8 @@ describe('bootswatch4', () => {
         helpers.assert.itWorks(response.statusCode, done);
     });
 
-    it('valid html', (done) => {
+    it('valid html', function(done) {
+        this.timeout(helpers.TESTS_TIMEOUT);
         helpers.assert.validHTML(response, done);
     });
 

--- a/test/bootswatch_legacy_test.js
+++ b/test/bootswatch_legacy_test.js
@@ -23,7 +23,8 @@ describe('bootswatch3', () => {
         helpers.assert.itWorks(response.statusCode, done);
     });
 
-    it('valid html', (done) => {
+    it('valid html', function(done) {
+        this.timeout(helpers.TESTS_TIMEOUT);
         helpers.assert.validHTML(response, done);
     });
 

--- a/test/fontawesome_legacy_test.js
+++ b/test/fontawesome_legacy_test.js
@@ -17,7 +17,8 @@ describe('legacy/fontawesome', () => {
         helpers.assert.itWorks(response.statusCode, done);
     });
 
-    it('valid html', (done) => {
+    it('valid html', function(done) {
+        this.timeout(helpers.TESTS_TIMEOUT);
         helpers.assert.validHTML(response, done);
     });
 

--- a/test/fontawesome_test.js
+++ b/test/fontawesome_test.js
@@ -23,7 +23,8 @@ describe('fontawesome', () => {
         done();
     });
 
-    it('valid html', (done) => {
+    it('valid html', function(done) {
+        this.timeout(helpers.TESTS_TIMEOUT);
         helpers.assert.validHTML(response, done);
     });
 

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -23,7 +23,8 @@ describe('index', () => {
         done();
     });
 
-    it('valid html', (done) => {
+    it('valid html', function(done) {
+        this.timeout(helpers.TESTS_TIMEOUT);
         helpers.assert.validHTML(response, done);
     });
 

--- a/test/integrations_test.js
+++ b/test/integrations_test.js
@@ -20,7 +20,8 @@ describe('integrations', () => {
         helpers.assert.itWorks(response.statusCode, done);
     });
 
-    it('valid html', (done) => {
+    it('valid html', function(done) {
+        this.timeout(helpers.TESTS_TIMEOUT);
         helpers.assert.validHTML(response, done);
     });
 

--- a/test/jobs_test.js
+++ b/test/jobs_test.js
@@ -15,7 +15,8 @@ describe('jobs', () => {
         helpers.assert.itWorks(response.statusCode, done);
     });
 
-    it('valid html', (done) => {
+    it('valid html', function(done) {
+        this.timeout(helpers.TESTS_TIMEOUT);
         helpers.assert.validHTML(response, done);
     });
 

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,9 +1,8 @@
 --check-leaks
 --globals __core-js_shared__
 --reporter dot
---slow 500
 --throw-deprecation
---timeout 15000
+--timeout 3000
 --trace-deprecation
 --trace-warnings
 --use_strict

--- a/test/privacy_policy_test.js
+++ b/test/privacy_policy_test.js
@@ -15,7 +15,8 @@ describe('privacy-policy', () => {
         helpers.assert.itWorks(response.statusCode, done);
     });
 
-    it('valid html', (done) => {
+    it('valid html', function(done) {
+        this.timeout(helpers.TESTS_TIMEOUT);
         helpers.assert.validHTML(response, done);
     });
 

--- a/test/showcase_test.js
+++ b/test/showcase_test.js
@@ -20,7 +20,8 @@ describe('showcase', () => {
         helpers.assert.itWorks(response.statusCode, done);
     });
 
-    it('valid html', (done) => {
+    it('valid html', function(done) {
+        this.timeout(helpers.TESTS_TIMEOUT);
         helpers.assert.validHTML(response, done);
     });
 

--- a/test/test_helpers.js
+++ b/test/test_helpers.js
@@ -15,6 +15,10 @@ const validator = require('html-validator');
 const app = require('../app.js');
 const config = require('../config');
 
+// This is our custom tests timeout;
+// used in HTML validation tests and the server.close function
+const TESTS_TIMEOUT = 5000;
+
 // The server object holds the server instance across all tests;
 // We start it in the first test and close it in the last one,
 // otherwise test time increases a lot (more than 3x)
@@ -212,5 +216,6 @@ module.exports = {
         pug: jsJade,
         html: jsHTML,
         haml: jsHAML
-    }
+    },
+    TESTS_TIMEOUT
 };

--- a/test/themes.js
+++ b/test/themes.js
@@ -16,7 +16,8 @@ describe('themes', () => {
         });
     });
 
-    after((done) => {
+    after(function(done) {
+        this.timeout(helpers.TESTS_TIMEOUT);
         helpers.stopServer(done);
     });
 
@@ -24,7 +25,8 @@ describe('themes', () => {
         helpers.assert.itWorks(response.statusCode, done);
     });
 
-    it('valid html', (done) => {
+    it('valid html', function(done) {
+        this.timeout(helpers.TESTS_TIMEOUT);
         helpers.assert.validHTML(response, done);
     });
 


### PR DESCRIPTION
When we expect tests to take longer, set the timeout to 5 seconds explicitly. Otherwise use a 3 second timeout.

@jmervine: this might need to be tweaked a little more, but from my tests, it seems 5 seconds is enough.

Fixes #1173.