### PR TITLE
Revert "Specify a nonce for styles too."

### DIFF
--- a/config/helmet-csp.js
+++ b/config/helmet-csp.js
@@ -29,8 +29,7 @@ const CSP = {
         'stackpath.bootstrapcdn.com',
         'fonts.googleapis.com',
         '*.twimg.com',
-        'platform.twitter.com',
-        (req, res) => `'nonce-${res.locals.nonce}'`
+        'platform.twitter.com'
     ],
     imgSrc: [
         '\'self\'',

--- a/views/layout.pug
+++ b/views/layout.pug
@@ -29,7 +29,7 @@ html(lang='en', prefix='og: http://ogp.me/ns#', itemscope, itemtype='http://sche
 
         block stylesheets
 
-        style(nonce=nonce)
+        style
             if (process.env.NODE_ENV === 'production')
                 include:clean-css /assets/css/style.css
             else


### PR DESCRIPTION
I was hoping the Twitter people would have fixed this but they haven't, so since it's bad to my eyes having console errors, better revert this for now.

We should revisit at some point later in case this gets fixed.