### PR TITLE
Expose resource timings

### DIFF
--- a/app.js
+++ b/app.js
@@ -104,6 +104,8 @@ app.use((req, res, next) => {
     res.setHeader('Last-Modified', new Date().toUTCString());
     res.setHeader('X-Hello-Human', 'Say hello back! @getBootstrapCDN on Twitter');
     res.setHeader('X-Powered-By', 'StackPath');
+    // https://www.w3.org/TR/resource-timing-2/
+    res.setHeader('Timing-Allow-Origin', '*');
 
     res.locals.nonce = nonce;
 


### PR DESCRIPTION
By adding this header, users of the CDN can inspect a lot more details
their resource loading, e.g. track asset sizes.

See https://www.w3.org/TR/resource-timing-2/#sec-timing-allow-origin
for details.

Fixes https://github.com/MaxCDN/bootstrapcdn/issues/1012