### PR TITLE
Fix CSP for Chrome.

### DIFF
--- a/config/helmet-csp.js
+++ b/config/helmet-csp.js
@@ -55,11 +55,13 @@ const CSP = {
     ],
     frameSrc: [
         '\'self\'',
+        'img.shields.io',
         'platform.twitter.com',
         'syndication.twitter.com'
     ],
     childSrc: [
         '\'self\'',
+        'img.shields.io',
         'platform.twitter.com',
         'syndication.twitter.com'
     ],


### PR DESCRIPTION
Apparently Chrome has a different CSP implementation than Firefox, and needs this in `frame-src`. Added it in `child-src` just in case it causes issues in ollder browsers.