### PR TITLE
Split config.

### DIFF
--- a/app.js
+++ b/app.js
@@ -36,6 +36,7 @@ const staticify    = require('staticify')(PUBLIC_DIR, {
 });
 
 const config  = require('./config');
+const CSP     = require('./config/helmet-csp');
 const helpers = require('./lib/helpers');
 const routes  = require('./routes');
 
@@ -97,7 +98,7 @@ if (NODE_ENV === 'production') {
 app.use(compression());
 app.use(staticify.middleware);
 
-app.use(favicon(path.join(PUBLIC_DIR, config.favicon.uri), '7d'));
+app.use(favicon(path.join(PUBLIC_DIR, config.app.favicon.uri), '7d'));
 
 app.use((req, res, next) => {
     // Create a nonce for use with CSP;
@@ -138,7 +139,7 @@ app.use(helmet.hsts({
 app.use(helmet.referrerPolicy({ policy: 'strict-origin-when-cross-origin' }));
 
 app.use(helmet.contentSecurityPolicy({
-    directives: config.CSP,
+    directives: CSP,
     // Set to false if you want to completely disable any user-agent sniffing.
     // This may make the headers less compatible but it will be much faster.
     // This defaults to `true`.

--- a/bin/www.js
+++ b/bin/www.js
@@ -2,9 +2,9 @@
 
 const http = require('http');
 const app = require('../app');
-const config = require('../config');
+const { port } = require('../config').app;
 
-app.set('port', process.env.PORT || config.port || 3000);
+app.set('port', process.env.PORT || port || 3000);
 
 const server = http.createServer(app);
 

--- a/config/index.js
+++ b/config/index.js
@@ -3,22 +3,15 @@
 const fs = require('fs');
 const path = require('path');
 const yaml = require('js-yaml');
-const csp = require('./helmet-csp');
 
 function loadConfig(file) {
     return yaml.safeLoad(fs.readFileSync(path.join(__dirname, file)), 'utf8');
 }
 
-function getConfigPath(file) {
-    return path.join(__dirname, file);
-}
+['_app.yml', '_extras.yml', '_files.yml'].forEach((file) => {
+    const name = file.replace(/^_/, '').replace(/.yml$/, '');
 
-['_app.yml', '_extras.yml', '_files.yml'].forEach((config) => {
-    module.exports = Object.assign(loadConfig(config), module.exports);
+    module.exports[name] = loadConfig(file);
 });
-
-module.exports.CSP = csp;
-module.exports.getConfigPath = getConfigPath;
-module.exports.loadConfig = loadConfig;
 
 // vim: ft=javascript sw=4 sts=4 et:

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -4,7 +4,7 @@ const fs = require('fs');
 const semver = require('semver');
 const sri = require('sri-toolbox');
 
-const config = require('../config');
+const { app, files } = require('../config');
 
 function generateSri(file, fromString) {
     file = fromString ? file : fs.readFileSync(file);
@@ -16,22 +16,22 @@ function generateSri(file, fromString) {
 
 function selectedTheme(selected) {
     if (typeof selected === 'undefined' || selected === '') {
-        return config.theme;
+        return app.theme;
     }
 
     return parseInt(selected, 10) === 0 || parseInt(selected, 10) ?
         parseInt(selected, 10) :
-        config.theme;
+        app.theme;
 }
 
 function getTheme(selected) {
-    const { themes } = config.bootswatch4;
+    const { themes } = files.bootswatch4;
 
     selected = selectedTheme(selected);
 
     return {
-        uri: config.bootswatch4.bootstrap
-                .replace('SWATCH_VERSION', config.bootswatch4.version)
+        uri: files.bootswatch4.bootstrap
+                .replace('SWATCH_VERSION', files.bootswatch4.version)
                 .replace('SWATCH_NAME', themes[selected].name),
         sri: themes[selected].sri
     };
@@ -44,7 +44,7 @@ function generateDataJson() {
         fontawesome: {}
     };
 
-    config.bootstrap.forEach((bootstrap) => {
+    files.bootstrap.forEach((bootstrap) => {
         const bootstrapVersion = bootstrap.version;
 
         if (semver.satisfies(semver.coerce(bootstrapVersion), '<4')) {
@@ -55,7 +55,7 @@ function generateDataJson() {
         }
     });
 
-    config.fontawesome.forEach((fontawesome) => {
+    files.fontawesome.forEach((fontawesome) => {
         data.fontawesome[fontawesome.version] = fontawesome.stylesheet;
     });
 

--- a/routes/appendLocals.js
+++ b/routes/appendLocals.js
@@ -2,7 +2,7 @@
 
 const path = require('path');
 const { generateSri } = require('../lib/helpers');
-const config = require('../config');
+const { app, files } = require('../config');
 
 const PUBLIC_DIR = path.join(__dirname, '../public/');
 const SRI_CACHE = {};
@@ -18,11 +18,11 @@ function getCurrentSiteurl(req) {
 }
 
 function getPageTitle(pageTitle) {
-    return `${pageTitle} · ${config.title_suffix}`;
+    return `${pageTitle} · ${app.title_suffix}`;
 }
 
 function getThemeQuery(req) {
-    const totalThemes = config.bootswatch4.themes.length;
+    const totalThemes = files.bootswatch4.themes.length;
     const query = req.query.theme;
 
     // Safety checks
@@ -59,7 +59,7 @@ function appendLocals(req, res) {
     const pageUrl = req.originalUrl;
     // OK, hack-ish way...
     const pathname = pageUrl.split('?')[0];
-    const canonicalUrl = new URL(pathname, config.siteurl);
+    const canonicalUrl = new URL(pathname, app.siteurl);
     const theme = getThemeQuery(req);
     const bodyClass = generateBodyClass(pathname);
 

--- a/scripts/integrity.js
+++ b/scripts/integrity.js
@@ -5,11 +5,10 @@
 const fs = require('fs');
 const path = require('path');
 const yaml = require('js-yaml');
-const config = require('../config');
+const { files } = require('../config');
 const { generateSri } = require('./sri');
 
-const filesConfig = config.loadConfig('_files.yml');
-const configFile = config.getConfigPath('_files.yml');
+const configFile = path.resolve(__dirname, '../config/_files.yml');
 
 function buildPath(dir) {
     dir = dir.replace('/bootstrap/', '/twitter-bootstrap/')
@@ -31,10 +30,10 @@ function exists(file) {
 // Bootswatch {3,4}
 ((() => {
     ['bootswatch3', 'bootswatch4'].forEach((key) => {
-        const bootswatch = buildPath(filesConfig[key].bootstrap);
+        const bootswatch = buildPath(files[key].bootstrap);
 
-        for (const theme of filesConfig[key].themes) {
-            const file = bootswatch.replace('SWATCH_VERSION', filesConfig[key].version)
+        for (const theme of files[key].themes) {
+            const file = bootswatch.replace('SWATCH_VERSION', files[key].version)
                                  .replace('SWATCH_NAME', theme.name);
 
             if (exists(file)) { // always regenerate
@@ -46,7 +45,7 @@ function exists(file) {
 
 // Bootlint
 ((() => {
-    for (const bootlint of filesConfig.bootlint) {
+    for (const bootlint of files.bootlint) {
         const file = buildPath(bootlint.javascript);
 
         if (exists(file)) {
@@ -57,7 +56,7 @@ function exists(file) {
 
 // Bootstrap
 ((() => {
-    for (const bootstrap of filesConfig.bootstrap) {
+    for (const bootstrap of files.bootstrap) {
         let { javascriptBundle } = bootstrap;
 
         const javascript = buildPath(bootstrap.javascript);
@@ -83,7 +82,7 @@ function exists(file) {
 
 // Font Awesome
 ((() => {
-    for (const fontawesome of filesConfig.fontawesome) {
+    for (const fontawesome of files.fontawesome) {
         const stylesheet = buildPath(fontawesome.stylesheet);
 
         if (exists(stylesheet)) {
@@ -96,7 +95,7 @@ function exists(file) {
 fs.copyFileSync(configFile, `${configFile}.bak`);
 
 fs.writeFileSync(configFile,
-    yaml.dump(filesConfig, {
+    yaml.dump(files, {
         lineWidth: -1
     })
 );

--- a/test/books_test.js
+++ b/test/books_test.js
@@ -4,10 +4,10 @@ const assert = require('assert').strict;
 const path = require('path');
 const { htmlEncode } = require('htmlencode');
 const staticify = require('staticify')(path.join(__dirname, '../public'));
+const { extras } = require('../config');
 const helpers = require('./test_helpers');
 
 describe('books', () => {
-    const config = helpers.getConfig();
     const uri = helpers.getURI('books');
     let response = {};
 
@@ -39,7 +39,7 @@ describe('books', () => {
         helpers.assert.bodyClass('page-books', response, done);
     });
 
-    config.books.forEach((book) => {
+    extras.books.forEach((book) => {
         describe(book.name, () => {
             it('has name', (done) => {
                 assert.ok(response.body.includes(book.name),

--- a/test/bootlint_legacy_test.js
+++ b/test/bootlint_legacy_test.js
@@ -1,10 +1,10 @@
 'use strict';
 
 const assert = require('assert').strict;
+const { files } = require('../config');
 const helpers = require('./test_helpers');
 
 describe('legacy/bootlint', () => {
-    const config = helpers.getConfig();
     const uri = helpers.getURI('legacy/bootlint');
     let response = {};
 
@@ -37,7 +37,7 @@ describe('legacy/bootlint', () => {
         helpers.assert.bodyClass('page-legacybootlint', response, done);
     });
 
-    config.bootlint.forEach((bootlint) => {
+    files.bootlint.forEach((bootlint) => {
         if (bootlint.current === true) {
             return;
         }

--- a/test/bootlint_test.js
+++ b/test/bootlint_test.js
@@ -1,12 +1,12 @@
 'use strict';
 
 const assert = require('assert').strict;
+const { files } = require('../config');
 const helpers = require('./test_helpers');
 
 describe('bootlint', () => {
-    const config = helpers.getConfig();
     const uri = helpers.getURI('bootlint');
-    const current = config.bootlint[0];
+    const current = files.bootlint[0];
     let response = {};
 
     before((done) => {

--- a/test/bootstrap_legacy_test.js
+++ b/test/bootstrap_legacy_test.js
@@ -1,10 +1,10 @@
 'use strict';
 
 const assert = require('assert').strict;
+const { files } = require('../config');
 const helpers = require('./test_helpers');
 
 describe('legacy/bootstrap', () => {
-    const config = helpers.getConfig();
     const uri = helpers.getURI('legacy/bootstrap');
     let response = {};
 
@@ -36,7 +36,7 @@ describe('legacy/bootstrap', () => {
         helpers.assert.bodyClass('page-legacybootstrap', response, done);
     });
 
-    config.bootstrap.forEach((bootstrap) => {
+    files.bootstrap.forEach((bootstrap) => {
         if (bootstrap.current === true) {
             return;
         }

--- a/test/bootswatch4_test.js
+++ b/test/bootswatch4_test.js
@@ -1,13 +1,12 @@
 'use strict';
 
 const assert = require('assert').strict;
+const { files } = require('../config');
 const helpers = require('./test_helpers');
-
-const config = helpers.getConfig();
 
 function format(str, name) {
     return str.replace('SWATCH_NAME', name)
-                .replace('SWATCH_VERSION', config.bootswatch4.version);
+                .replace('SWATCH_VERSION', files.bootswatch4.version);
 }
 
 describe('bootswatch4', () => {
@@ -61,10 +60,10 @@ describe('bootswatch4', () => {
         });
     });
 
-    config.bootswatch4.themes.forEach((theme) => {
+    files.bootswatch4.themes.forEach((theme) => {
         describe(theme.name, () => {
-            const themeImage = format(config.bootswatch4.image, theme.name);
-            const themeUri   = format(config.bootswatch4.bootstrap, theme.name);
+            const themeImage = format(files.bootswatch4.image, theme.name);
+            const themeUri   = format(files.bootswatch4.bootstrap, theme.name);
             const themeSri   = theme.sri;
 
             it('has image', (done) => {

--- a/test/bootswatch_legacy_test.js
+++ b/test/bootswatch_legacy_test.js
@@ -1,13 +1,12 @@
 'use strict';
 
 const assert = require('assert').strict;
+const { files } = require('../config');
 const helpers = require('./test_helpers');
-
-const config = helpers.getConfig();
 
 function format(str, name) {
     return str.replace('SWATCH_NAME', name)
-                .replace('SWATCH_VERSION', config.bootswatch3.version);
+                .replace('SWATCH_VERSION', files.bootswatch3.version);
 }
 
 describe('bootswatch3', () => {
@@ -42,10 +41,10 @@ describe('bootswatch3', () => {
         helpers.assert.bodyClass('page-legacybootswatch', response, done);
     });
 
-    config.bootswatch3.themes.forEach((theme) => {
+    files.bootswatch3.themes.forEach((theme) => {
         describe(theme.name, () => {
-            const themeImage = format(config.bootswatch3.image, theme.name);
-            const themeUri = format(config.bootswatch3.bootstrap, theme.name);
+            const themeImage = format(files.bootswatch3.image, theme.name);
+            const themeUri = format(files.bootswatch3.bootstrap, theme.name);
             const themeSri = theme.sri;
 
             it('has image', (done) => {

--- a/test/fontawesome_legacy_test.js
+++ b/test/fontawesome_legacy_test.js
@@ -1,10 +1,10 @@
 'use strict';
 
 const assert = require('assert').strict;
+const { files } = require('../config');
 const helpers = require('./test_helpers');
 
 describe('legacy/fontawesome', () => {
-    const config = helpers.getConfig();
     const uri = helpers.getURI('legacy/fontawesome');
     let response = {};
 
@@ -36,7 +36,7 @@ describe('legacy/fontawesome', () => {
         helpers.assert.bodyClass('page-legacyfontawesome', response, done);
     });
 
-    config.fontawesome.forEach((fontawesome) => {
+    files.fontawesome.forEach((fontawesome) => {
         if (fontawesome.current === true) {
             return;
         }

--- a/test/fontawesome_test.js
+++ b/test/fontawesome_test.js
@@ -1,12 +1,12 @@
 'use strict';
 
 const assert = require('assert').strict;
+const { files } = require('../config');
 const helpers = require('./test_helpers');
 
 describe('fontawesome', () => {
-    const config = helpers.getConfig();
     const uri = helpers.getURI('fontawesome');
-    const current = config.fontawesome[0];
+    const current = files.fontawesome[0];
     let response = {};
 
     before((done) => {

--- a/test/functional_test.js
+++ b/test/functional_test.js
@@ -12,9 +12,9 @@ const path = require('path');
 const semver = require('semver');
 const walk = require('fs-walk');
 const { generateSri } = require('../lib/helpers');
+const { files } = require('../config');
 const helpers = require('./test_helpers');
 
-const config = helpers.getConfig();
 const CDN_URL = 'https://stackpath.bootstrapcdn.com/';
 const responses = {};
 
@@ -164,7 +164,7 @@ function assertContentType(uri, currentType, cb) {
 }
 
 describe('functional', () => {
-    config.bootstrap.forEach((self) => {
+    files.bootstrap.forEach((self) => {
         describe(domainCheck(self.javascript), () => {
             const uri = domainCheck(self.javascript);
 
@@ -235,9 +235,9 @@ describe('functional', () => {
     });
 
     describe('bootswatch3', () => {
-        config.bootswatch3.themes.forEach((theme) => {
-            const uri = domainCheck(config.bootswatch3.bootstrap
-                .replace('SWATCH_VERSION', config.bootswatch3.version)
+        files.bootswatch3.themes.forEach((theme) => {
+            const uri = domainCheck(files.bootswatch3.bootstrap
+                .replace('SWATCH_VERSION', files.bootswatch3.version)
                 .replace('SWATCH_NAME', theme.name));
 
             describe(uri, () => {
@@ -263,9 +263,9 @@ describe('functional', () => {
     });
 
     describe('bootswatch4', () => {
-        config.bootswatch4.themes.forEach((theme) => {
-            const uri = domainCheck(config.bootswatch4.bootstrap
-                .replace('SWATCH_VERSION', config.bootswatch4.version)
+        files.bootswatch4.themes.forEach((theme) => {
+            const uri = domainCheck(files.bootswatch4.bootstrap
+                .replace('SWATCH_VERSION', files.bootswatch4.version)
                 .replace('SWATCH_NAME', theme.name));
 
             describe(uri, () => {
@@ -291,7 +291,7 @@ describe('functional', () => {
     });
 
     describe('bootlint', () => {
-        config.bootlint.forEach((self) => {
+        files.bootlint.forEach((self) => {
             const uri = domainCheck(self.javascript);
 
             describe(uri, () => {
@@ -317,7 +317,7 @@ describe('functional', () => {
     });
 
     describe('fontawesome', () => {
-        config.fontawesome.forEach((self) => {
+        files.fontawesome.forEach((self) => {
             const uri = domainCheck(self.stylesheet);
 
             describe(uri, () => {

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -1,12 +1,12 @@
 'use strict';
 
 const assert = require('assert').strict;
+const { files } = require('../config');
 const helpers = require('./test_helpers');
 
 describe('index', () => {
-    const config = helpers.getConfig();
     const uri = helpers.getURI();
-    const current = config.bootstrap[0];
+    const current = files.bootstrap[0];
     let response = {};
 
     before((done) => {

--- a/test/integrations_test.js
+++ b/test/integrations_test.js
@@ -4,10 +4,10 @@ const assert = require('assert').strict;
 const path = require('path');
 const { htmlEncode } = require('htmlencode');
 const staticify = require('staticify')(path.join(__dirname, '../public'));
+const { extras } = require('../config');
 const helpers = require('./test_helpers');
 
 describe('integrations', () => {
-    const config = helpers.getConfig();
     const uri = helpers.getURI('integrations');
     let response = {};
 
@@ -39,7 +39,7 @@ describe('integrations', () => {
         helpers.assert.bodyClass('page-integrations', response, done);
     });
 
-    config.integrations.forEach((integration) => {
+    extras.integrations.forEach((integration) => {
         describe(integration.name, () => {
             it('has name', (done) => {
                 assert.ok(response.body.includes(integration.name),

--- a/test/redirects_test.js
+++ b/test/redirects_test.js
@@ -1,12 +1,10 @@
 'use strict';
 
 const assert = require('assert').strict;
+const { redirects } = require('../config').app;
 const helpers = require('./test_helpers');
 
 describe('redirects', () => {
-    const config = helpers.getConfig();
-    const { redirects } = config;
-
     for (const redirect in redirects) {
         if (Object.prototype.hasOwnProperty.call(redirects, redirect)) {
             const redirectFrom = redirects[redirect].from;

--- a/test/showcase_test.js
+++ b/test/showcase_test.js
@@ -4,10 +4,10 @@ const assert = require('assert').strict;
 const path = require('path');
 const { htmlEncode } = require('htmlencode');
 const staticify = require('staticify')(path.join(__dirname, '../public'));
+const { extras } = require('../config');
 const helpers = require('./test_helpers');
 
 describe('showcase', () => {
-    const config = helpers.getConfig();
     const uri = helpers.getURI('showcase');
     let response = {};
 
@@ -39,7 +39,7 @@ describe('showcase', () => {
         helpers.assert.bodyClass('page-showcase', response, done);
     });
 
-    config.showcase.forEach((showcase) => {
+    extras.showcase.forEach((showcase) => {
         describe(showcase.name, () => {
             it('has name', (done) => {
                 assert.ok(response.body.includes(showcase.name),

--- a/test/test_helpers.js
+++ b/test/test_helpers.js
@@ -15,7 +15,7 @@ const request = require('request');
 const validator = require('html-validator');
 
 const app = require('../app');
-const config = require('../config');
+const config = require('../config').app;
 
 // The server object holds the server instance across all tests;
 // We start it in the first test and close it in the last one,
@@ -38,12 +38,6 @@ function getExtension(str) {
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions
 function escapeRegExp(string) {
     return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // $& means the whole matched string
-}
-
-// Just returning the existent config so that
-// we don't have to import lib/helpers in tests.
-function getConfig() {
-    return config;
 }
 
 function cleanEndpoint(endpoint = '/') {
@@ -195,7 +189,6 @@ function jsHAML(uri, sri) {
 }
 
 module.exports = {
-    getConfig,
     getExtension,
     getURI,
     startServer,

--- a/test/themes_test.js
+++ b/test/themes_test.js
@@ -4,10 +4,10 @@ const assert = require('assert').strict;
 const path = require('path');
 const { htmlEncode } = require('htmlencode');
 const staticify = require('staticify')(path.join(__dirname, '../public'));
+const { extras } = require('../config');
 const helpers = require('./test_helpers');
 
 describe('themes', () => {
-    const config = helpers.getConfig();
     const uri = helpers.getURI('themes');
     let response = {};
 
@@ -43,7 +43,7 @@ describe('themes', () => {
         helpers.assert.bodyClass('page-themes', response, done);
     });
 
-    config.themesAd.forEach((theme) => {
+    extras.themesAd.forEach((theme) => {
         describe(theme.name, () => {
             it('has name', (done) => {
                 assert.ok(response.body.includes(htmlEncode(theme.name)),

--- a/views/_partials/footer.pug
+++ b/views/_partials/footer.pug
@@ -4,8 +4,8 @@ footer.mt-5.py-4.text-center
             .col-12
                 p
                     | Maintained by 
-                    each author, index in config.authors
-                        if (index === config.authors.length - 1)
+                    each author, index in config.app.authors
+                        if (index === config.app.authors.length - 1)
                             |  &amp; 
                         else if (index > 0)
                             | , 
@@ -17,8 +17,8 @@ footer.mt-5.py-4.text-center
 
                 p
                     | Homies be 
-                    each friend, index in config.friends
-                        if (index === config.friends.length - 1)
+                    each friend, index in config.extras.friends
+                        if (index === config.extras.friends.length - 1)
                             |  &amp; 
                         else if (index > 0)
                             | , 

--- a/views/_partials/loadjs.pug
+++ b/views/_partials/loadjs.pug
@@ -1,11 +1,11 @@
 -
-    var bootswatchVersion = semver.coerce(config.bootswatch4.version);
-    var bootstrap = config.bootstrap.find(file => semver.satisfies(file.version, `~${bootswatchVersion}`));
-    var jquery = config.javascript.find(file => file.name === 'jquery');
-    var clipboardjs = config.javascript.find(file => file.name === 'clipboardjs');
+    var bootswatchVersion = semver.coerce(config.files.bootswatch4.version);
+    var bootstrap = config.files.bootstrap.find(file => semver.satisfies(file.version, `~${bootswatchVersion}`));
+    var jquery = config.app.javascript.find(file => file.name === 'jquery');
+    var clipboardjs = config.app.javascript.find(file => file.name === 'clipboardjs');
     var clipboardjsUri = getVersionedPath(clipboardjs.uri);
     var clipboardjsSri = generateSRI(clipboardjs.uri);
-    var mainJs = config.javascript.find(file => file.name === 'main');
+    var mainJs = config.app.javascript.find(file => file.name === 'main');
     var mainJsUri = getVersionedPath(mainJs.uri);
     var mainJsSri = generateSRI(mainJs.uri);
 

--- a/views/about.pug
+++ b/views/about.pug
@@ -6,7 +6,7 @@ block content
 
             h2.text-center.mb-4 About
 
-            -var authors=config.authors;
+            -var authors=config.app.authors;
 
             p.
                 BootstrapCDN was founded in 2012 by #[a(href='https://twitter.com/DavidHenzel', rel='noopener', target='_blank') David Henzel]

--- a/views/books.pug
+++ b/views/books.pug
@@ -10,7 +10,7 @@ block content
         a(href='/about/#sustainability') What’s this?
 
     .row
-        each book in config.books
+        each book in config.extras.books
             .col-12.col-md-6
                 include _partials/book.pug
 

--- a/views/bootlint.pug
+++ b/views/bootlint.pug
@@ -5,8 +5,8 @@ block content
 
     .card.bg-light.mt-4.p-4.text-center
         -var name   = 'bootlintjs';
-        -var file   = config.bootlint[0].javascript;
-        -var sri    = config.bootlint[0].javascriptSri;
+        -var file   = config.files.bootlint[0].javascript;
+        -var sri    = config.files.bootlint[0].javascriptSri;
         -var formId = `${name}_form`;
 
         .form-group.my-4

--- a/views/bootswatch.pug
+++ b/views/bootswatch.pug
@@ -3,10 +3,10 @@ extends layout.pug
 block content
     h2.text-center.mb-4 Bootswatch 4
 
-    each item, index in config.bootswatch4.themes
+    each item, index in config.files.bootswatch4.themes
         -var name = item.name.toLowerCase();
         -var sri  = item.sri;
-        -var file = config.bootswatch4.bootstrap.replace('SWATCH_NAME', name).replace('SWATCH_VERSION', config.bootswatch4.version);
+        -var file = config.files.bootswatch4.bootstrap.replace('SWATCH_NAME', name).replace('SWATCH_VERSION', config.files.bootswatch4.version);
 
         .card.bg-light.my-4.p-4.text-center
             .row
@@ -18,8 +18,8 @@ block content
                             a.btn.btn-primary(role='button', href=`?theme=${index}`) Try it!
                 .col-12.col-md-8
                     .mt-4
-                        a(href=config.bootswatch4.link.replace('SWATCH_NAME', name), rel='noopener', target='_blank')
-                            img.bootswatch.d-block.img-fluid.mx-auto(src=config.bootswatch4.image.replace('SWATCH_NAME', name), alt=`${name} thumbnail`, width='528', height='317')
+                        a(href=config.files.bootswatch4.link.replace('SWATCH_NAME', name), rel='noopener', target='_blank')
+                            img.bootswatch.d-block.img-fluid.mx-auto(src=config.files.bootswatch4.image.replace('SWATCH_NAME', name), alt=`${name} thumbnail`, width='528', height='317')
                         .input-group.mt-3
                             input.form-control(type='text', value=file)
                             .input-group-append

--- a/views/fontawesome.pug
+++ b/views/fontawesome.pug
@@ -7,8 +7,8 @@ block content
 
     .card.bg-light.mt-4.p-4.text-center
         -var name   = 'fontawesomecss';
-        -var file   = config.fontawesome[0].stylesheet;
-        -var sri    = config.fontawesome[0].stylesheetSri;
+        -var file   = config.files.fontawesome[0].stylesheet;
+        -var sri    = config.files.fontawesome[0].stylesheetSri;
         -var formId = `${name}_form`;
 
         .form-group.my-4

--- a/views/index.pug
+++ b/views/index.pug
@@ -5,7 +5,7 @@ block content
     
     h2.text-center=title
 
-    -var current = config.bootstrap[0];
+    -var current = config.files.bootstrap[0];
     h3.text-center.mt-4=`v${current.version}`
 
     .card.bg-light.mt-4.p-4.text-center

--- a/views/integrations.pug
+++ b/views/integrations.pug
@@ -4,7 +4,7 @@ block content
     h2.text-center.mb-4 Integrations
 
     .row
-        each item in config.integrations
+        each item in config.extras.integrations
             .col-12.col-md-6
                 include _partials/integrations.pug
 

--- a/views/layout.pug
+++ b/views/layout.pug
@@ -3,9 +3,9 @@ html(lang='en', prefix='og: http://ogp.me/ns#', itemscope, itemtype='http://sche
     head
         meta(charset='utf-8')
         meta(name='viewport', content='width=device-width, initial-scale=1, shrink-to-fit=no')
-        meta(name='author', content=config.authors.map(author => author.name).join(', '))
+        meta(name='author', content=config.app.authors.map(author => author.name).join(', '))
 
-        -var pageDescription = description || config.description;
+        -var pageDescription = description || config.app.description;
         meta(name='description', content!=pageDescription)
 
         title!=getPageTitle(title)

--- a/views/legacy/bootlint.pug
+++ b/views/legacy/bootlint.pug
@@ -3,7 +3,7 @@ extends ../layout.pug
 block content
     h2.text-center.mb-4 Bootlint Legacy
 
-    each item in config.bootlint
+    each item in config.files.bootlint
         unless (item.current)
             .card.bg-light.mt-4.p-4.text-center
                 h3.mt-2=`v${item.version}`

--- a/views/legacy/bootstrap.pug
+++ b/views/legacy/bootstrap.pug
@@ -3,7 +3,7 @@ extends ../layout.pug
 block content
     h2.text-center.mb-4 Bootstrap Legacy
 
-    each item in config.bootstrap
+    each item in config.files.bootstrap
         unless (item.current)
             .card.bg-light.mt-4.p-4.text-center
                 h3.mt-2=`v${item.version}`

--- a/views/legacy/bootswatch.pug
+++ b/views/legacy/bootswatch.pug
@@ -3,17 +3,17 @@ extends ../layout.pug
 block content
     h2.text-center.mb-4 Bootswatch 3
 
-    each item in config.bootswatch3.themes
+    each item in config.files.bootswatch3.themes
         -var name = item.name.toLowerCase();
         -var sri  = item.sri;
-        -var file = config.bootswatch3.bootstrap.replace('SWATCH_NAME', name).replace('SWATCH_VERSION', config.bootswatch3.version);
+        -var file = config.files.bootswatch3.bootstrap.replace('SWATCH_NAME', name).replace('SWATCH_VERSION', config.files.bootswatch3.version);
 
         .card.bg-light.my-4.p-4.text-center
             .row
                 .col-12.col-md-8.offset-md-2
                     .mt-4
-                        a(href=config.bootswatch3.link.replace('SWATCH_NAME', name), rel='noopener', target='_blank')
-                            img.bootswatch.d-block.img-fluid.mx-auto(src=config.bootswatch3.image.replace('SWATCH_NAME', name), alt=`${name} thumbnail`, width='528', height='317')
+                        a(href=config.files.bootswatch3.link.replace('SWATCH_NAME', name), rel='noopener', target='_blank')
+                            img.bootswatch.d-block.img-fluid.mx-auto(src=config.files.bootswatch3.image.replace('SWATCH_NAME', name), alt=`${name} thumbnail`, width='528', height='317')
                         .input-group.mt-3
                             input.form-control(type='text', value=file)
                             .input-group-append

--- a/views/legacy/fontawesome.pug
+++ b/views/legacy/fontawesome.pug
@@ -3,7 +3,7 @@ extends ../layout.pug
 block content
     h2.text-center.mb-4 Font Awesome Legacy
 
-    each item in config.fontawesome
+    each item in config.files.fontawesome
         unless (item.current)
             .card.bg-light.mt-4.p-4.text-center
                 h3.mt-2=`v${item.version}`

--- a/views/privacy-policy.pug
+++ b/views/privacy-policy.pug
@@ -1,7 +1,7 @@
 extends layout.pug
 
 block stylesheets
-    -var iubenda = config.stylesheet.find(file => file.name === 'iubenda');
+    -var iubenda = config.app.stylesheet.find(file => file.name === 'iubenda');
     link(rel='stylesheet', href=getVersionedPath(iubenda.uri),
          integrity=generateSRI(iubenda.uri), crossorigin='anonymous')
 

--- a/views/showcase.pug
+++ b/views/showcase.pug
@@ -4,7 +4,7 @@ block content
     h2.text-center.mb-4 Showcase
 
     .row
-        each item in config.showcase
+        each item in config.extras.showcase
             .col-12.col-md-6
                 include _partials/showcase.pug
 

--- a/views/themes.pug
+++ b/views/themes.pug
@@ -10,7 +10,7 @@ block content
         a(href='/about/#sustainability') What’s this?
 
     .row
-        each theme in config.themesAd
+        each theme in config.extras.themesAd
             .col-12.col-md-6
                 include _partials/theme.pug
 


### PR DESCRIPTION
I guess when we split the config, @jmervine chose to merge them to the `config` object to make things easier.

IMO, it's better to be explicit than having to deal with a huge config object which included also useless stuff like the helmet CSP config object, etc.

This should also improve response times in some cases, although arguably, the second time, the object will be cached anyway, so this is mostly visible when developing. And in some other cases, response times might be slightly slower, but again only for the first request IIRC.

/CC @johann-s for thoughts too :)