### PR TITLE
Use `codefund.io` for ad render

### DIFF
--- a/config/helmet-csp.js
+++ b/config/helmet-csp.js
@@ -46,6 +46,7 @@ const CSP = {
         'codefund.app',
         'cdn2.codefund.app',
         'codefund.io',
+        'cdn.codefund.io',
         'launchbit.com',
         'www.launchbit.com',
         'www.ziprecruiter.com'
@@ -69,7 +70,8 @@ const CSP = {
     ],
     connectSrc: [
         'syndication.twitter.com',
-        'cdn2.codefund.app'
+        'cdn2.codefund.app',
+        'cdn.codefund.io'
     ],
     objectSrc: [
         'img.shields.io'

--- a/views/_partials/codefund.pug
+++ b/views/_partials/codefund.pug
@@ -2,4 +2,4 @@
     #codefund
 
 block scripts
-    script(async, src='https://codefund.app/properties/101/funder.js')
+    script(async, src='https://codefund.io/properties/101/funder.js')

--- a/views/about.pug
+++ b/views/about.pug
@@ -97,7 +97,7 @@ block content
 
             p.
                 In May 2018, we created #[a(href='https://opencollective.com/getbootstrapcdn', rel='noopener', target='_blank') an organization on Open Collective].
-                We use the collective for any money we make from ethical advertisements (#[a(href='https://codefund.app/?utm_campaign=partner&utm_source=bootstrapcdn&utm_medium=bootstrapcdn', rel='noopener', target='_blank') CodeFund])
+                We use the collective for any money we make from ethical advertisements (#[a(href='https://codefund.io/invite/EBoAxC6PuGU', rel='noopener', target='_blank') CodeFund])
                 and affiliate commissions (#[a(href='/themes/') Themes], #[a(href='/books/') Books] and #[a(href='/jobs/') Jobs]).
                 This allows us to do the following:
 


### PR DESCRIPTION
We are now using codefund.io instead of codefund.app for rendering ethical ads. I also added the new CDN URL that we will be migrating to. Finally, I updated your link to CodeFund to use your referral link.