### PR TITLE
Add lgtm.com support.

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -1,0 +1,14 @@
+# https://lgtm.com/help/lgtm/customizing-file-classification
+path_classifiers:
+  cdn:
+    - cdn/
+
+extraction:
+  javascript:
+    # The `index` step extracts information from the files in the codebase.
+    index:
+      # Specify a list of files and folders to exclude from extraction.
+      filters:
+        - exclude: cdn/
+      exclude:
+        - cdn/

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # BootstrapCDN
 
+[![Total alerts](https://img.shields.io/lgtm/alerts/g/MaxCDN/bootstrapcdn.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/MaxCDN/bootstrapcdn/alerts/)
 [![Build Status](https://img.shields.io/circleci/project/github/MaxCDN/bootstrapcdn/develop.svg?style=flat-square)](https://circleci.com/gh/MaxCDN/bootstrapcdn)
 [![Coverage Status](https://img.shields.io/coveralls/github/MaxCDN/bootstrapcdn/develop.svg?style=flat-square)](https://coveralls.io/github/MaxCDN/bootstrapcdn)
 [![dependencies Status](https://img.shields.io/david/MaxCDN/bootstrapcdn.svg?style=flat-square)](https://david-dm.org/MaxCDN/bootstrapcdn)


### PR DESCRIPTION
@jmervine can you enable the lgtm GitHub App? Now it's using the hooks which is deprecated.