### PR TITLE
Add `readonly` in text `input`s.

### DIFF
--- a/views/_partials/csscode.pug
+++ b/views/_partials/csscode.pug
@@ -4,19 +4,19 @@
             -var formId = `html_${name}`;
             label.font-weight-bold(for=formId)
                 a(href='https://www.w3.org/html/', rel='noopener', target='_blank') HTML
-            input.form-control(id=formId, type='text', value=`<link href="${file}" rel="stylesheet" integrity="${sri}" crossorigin="anonymous">`)
+            input.form-control(id=formId, type='text', readonly, value=`<link href="${file}" rel="stylesheet" integrity="${sri}" crossorigin="anonymous">`)
             span.form-text.text-muted Click to copy
         .form-group
             -var formId = `pug_${name}`;
             label.font-weight-bold(for=formId)
                 a(href='https://pugjs.org/', rel='noopener', target='_blank') Pug
-            input.form-control(id=formId, type='text', value=`link(href="${file}", rel="stylesheet", integrity="${sri}", crossorigin="anonymous")`)
+            input.form-control(id=formId, type='text', readonly, value=`link(href="${file}", rel="stylesheet", integrity="${sri}", crossorigin="anonymous")`)
             span.form-text.text-muted Click to copy
         .form-group.mb-4
             -var formId = `haml_${name}`;
             label.font-weight-bold(for=formId)
                 a(href='http://haml.info/', rel='noopener', target='_blank') Haml
-            input.form-control(id=formId, type='text', value=`%link{href: "${file}", rel: "stylesheet", integrity: "${sri}", crossorigin: "anonymous"}`)
+            input.form-control(id=formId, type='text', readonly, value=`%link{href: "${file}", rel: "stylesheet", integrity: "${sri}", crossorigin: "anonymous"}`)
             span.form-text.text-muted Click to copy
 
 //- vim: ft=pug sw=4 sts=4 et:

--- a/views/_partials/jscode.pug
+++ b/views/_partials/jscode.pug
@@ -4,19 +4,19 @@
             -var formId = `html_${name}`;
             label.font-weight-bold(for=formId)
                 a(href='https://www.w3.org/html/', rel='noopener', target='_blank') HTML
-            input.form-control(id=formId, type='text', value=`<script src="${file}" integrity="${sri}" crossorigin="anonymous"></script>`)
+            input.form-control(id=formId, type='text', readonly, value=`<script src="${file}" integrity="${sri}" crossorigin="anonymous"></script>`)
             span.form-text.text-muted Click to copy
         .form-group
             -var formId = `pug_${name}`;
             label.font-weight-bold(for=formId)
                 a(href='https://pugjs.org/', rel='noopener', target='_blank') Pug
-            input.form-control(id=formId, type='text', value=`script(src="${file}", integrity="${sri}", crossorigin="anonymous")`)
+            input.form-control(id=formId, type='text', readonly, value=`script(src="${file}", integrity="${sri}", crossorigin="anonymous")`)
             span.form-text.text-muted Click to copy
         .form-group.mb-4
             -var formId = `haml_${name}`;
             label.font-weight-bold(for=formId)
                 a(href='http://haml.info/', rel='noopener', target='_blank') Haml
-            input.form-control(id=formId, type='text', value=`%script{src: "${file}", integrity: "${sri}", crossorigin: "anonymous"}`)
+            input.form-control(id=formId, type='text', readonly, value=`%script{src: "${file}", integrity: "${sri}", crossorigin: "anonymous"}`)
             span.form-text.text-muted Click to copy
 
 //- vim: ft=pug sw=4 sts=4 et:

--- a/views/bootlint.pug
+++ b/views/bootlint.pug
@@ -13,7 +13,7 @@ block content
         .form-group.my-4
             label.font-weight-bold(for=formId) Complete JavaScript
             .input-group.input-group-lg
-                input.form-control(id=formId, type='text', value=file)
+                input.form-control(id=formId, type='text', readonly, value=file)
                 .input-group-append
                     button.btn.btn-dark.dropdown-toggle(type='button', data-toggle='collapse', data-target=`#${name}`, aria-label='Toggle Dropdown', aria-expanded='false', aria-controls=name)
             span.form-text.text-muted Click to copy

--- a/views/bootswatch.pug
+++ b/views/bootswatch.pug
@@ -22,7 +22,7 @@ block content
                         a(href=config.files.bootswatch4.link.replace('SWATCH_NAME', name), rel='noopener', target='_blank')
                             img.bootswatch.d-block.img-fluid.mx-auto(src=config.files.bootswatch4.image.replace('SWATCH_NAME', name), alt=`${capitalizedThemeName} theme's thumbnail`, title=`Visit ${capitalizedThemeName} theme's demo page`, width='528', height='317')
                         .input-group.mt-3
-                            input.form-control(type='text', value=file, aria-label=`${capitalizedThemeName} theme's CSS file`)
+                            input.form-control(type='text', readonly, value=file, aria-label=`${capitalizedThemeName} theme's CSS file`)
                             .input-group-append
                                 button.btn.btn-dark.dropdown-toggle(type='button', data-toggle='collapse', data-target=`#${name}`, aria-label='Toggle Dropdown', aria-expanded='false', aria-controls=name)
                         span.form-text.text-muted.mb-4 Click to copy

--- a/views/fontawesome.pug
+++ b/views/fontawesome.pug
@@ -15,7 +15,7 @@ block content
         .form-group.my-4
             label.font-weight-bold(for=formId) Font Awesome CSS
             .input-group.input-group-lg
-                input.form-control(id=formId, type='text', value=file)
+                input.form-control(id=formId, type='text', readonly, value=file)
                 .input-group-append
                     button.btn.btn-dark.dropdown-toggle(type='button', data-toggle='collapse', data-target=`#${name}`, aria-label='Toggle Dropdown', aria-expanded='false', aria-controls=name)
             span.form-text.text-muted Click to copy

--- a/views/index.pug
+++ b/views/index.pug
@@ -17,7 +17,7 @@ block content
         .form-group.my-4
             label.font-weight-bold(for=formId) Complete CSS
             .input-group.input-group-lg
-                input.form-control(id=formId, type='text', value=file)
+                input.form-control(id=formId, type='text', readonly, value=file)
                 .input-group-append
                     button.btn.btn-dark.dropdown-toggle(type='button', data-toggle='collapse', data-target=`#${name}`, aria-label='Toggle Dropdown', aria-expanded='false', aria-controls=name)
             span.form-text.text-muted Click to copy
@@ -32,7 +32,7 @@ block content
         .form-group.my-4
             label.font-weight-bold(for=formId) Complete JavaScript
             .input-group.input-group-lg
-                input.form-control(id=formId, type='text', value=file)
+                input.form-control(id=formId, type='text', readonly, value=file)
                 .input-group-append
                     button.btn.btn-dark.dropdown-toggle(type='button', data-toggle='collapse', data-target=`#${name}`, aria-label='Toggle Dropdown', aria-expanded='false', aria-controls=name)
             span.form-text.text-muted Click to copy
@@ -47,7 +47,7 @@ block content
         .form-group.my-4
             label.font-weight-bold(for=formId) Complete JavaScript Bundle
             .input-group.input-group-lg
-                input.form-control(id=formId, type='text', value=file)
+                input.form-control(id=formId, type='text', readonly, value=file)
                 .input-group-append
                     button.btn.btn-dark.dropdown-toggle(type='button', data-toggle='collapse', data-target=`#${name}`, aria-label='Toggle Dropdown', aria-expanded='false', aria-controls=name)
             span.form-text.text-muted Click to copy

--- a/views/legacy/bootlint.pug
+++ b/views/legacy/bootlint.pug
@@ -16,7 +16,7 @@ block content
                 .form-group.my-4
                     label.font-weight-bold(for=formId) Complete JS
                     .input-group.input-group-lg
-                        input.form-control(id=formId, type='text', value=file)
+                        input.form-control(id=formId, type='text', readonly, value=file)
                         .input-group-append
                             button.btn.btn-dark.dropdown-toggle(type='button', data-toggle='collapse', data-target=`#${name}`, aria-label='Toggle Dropdown', aria-expanded='false', aria-controls=name)
                     span.form-text.text-muted Click to copy

--- a/views/legacy/bootstrap.pug
+++ b/views/legacy/bootstrap.pug
@@ -16,7 +16,7 @@ block content
                 .form-group.my-4
                     label.font-weight-bold(for=formId) Complete CSS
                     .input-group.input-group-lg
-                        input.form-control(id=formId, type='text', value=file)
+                        input.form-control(id=formId, type='text', readonly, value=file)
                         .input-group-append
                             button.btn.btn-dark.dropdown-toggle(type='button', data-toggle='collapse', data-target=`#${name}`, aria-label='Toggle Dropdown', aria-expanded='false', aria-controls=name)
                     span.form-text.text-muted Click to copy
@@ -31,7 +31,7 @@ block content
                 .form-group.my-4
                     label.font-weight-bold(for=formId) Complete JavaScript
                     .input-group.input-group-lg
-                        input.form-control(id=formId, type='text', value=file)
+                        input.form-control(id=formId, type='text', readonly, value=file)
                         .input-group-append
                             button.btn.btn-dark.dropdown-toggle(type='button', data-toggle='collapse', data-target=`#${name}`, aria-label='Toggle Dropdown', aria-expanded='false', aria-controls=name)
                     span.form-text.text-muted Click to copy
@@ -47,7 +47,7 @@ block content
                     .form-group.my-4
                         label.font-weight-bold(for=formId) Complete JavaScript Bundle
                         .input-group.input-group-lg
-                            input.form-control(id=formId, type='text', value=file)
+                            input.form-control(id=formId, type='text', readonly, value=file)
                             .input-group-append
                                 button.btn.btn-dark.dropdown-toggle(type='button', data-toggle='collapse', data-target=`#${name}`, aria-label='Toggle Dropdown', aria-expanded='false', aria-controls=name)
                         span.form-text.text-muted Click to copy

--- a/views/legacy/bootswatch.pug
+++ b/views/legacy/bootswatch.pug
@@ -16,7 +16,7 @@ block content
                         a(href=config.files.bootswatch3.link.replace('SWATCH_NAME', name), rel='noopener', target='_blank')
                             img.bootswatch.d-block.img-fluid.mx-auto(src=config.files.bootswatch3.image.replace('SWATCH_NAME', name), alt=`${capitalizedThemeName} theme's thumbnail`, title=`Visit ${capitalizedThemeName} theme's demo page`, width='528', height='317')
                         .input-group.mt-3
-                            input.form-control(type='text', value=file, aria-label=`${capitalizedThemeName} theme's CSS file`)
+                            input.form-control(type='text', readonly, value=file, aria-label=`${capitalizedThemeName} theme's CSS file`)
                             .input-group-append
                                 button.btn.btn-dark.dropdown-toggle(type='button', data-toggle='collapse', data-target=`#${name}`, aria-label='Toggle Dropdown', aria-expanded='false', aria-controls=name)
                         span.form-text.text-muted.mb-4 Click to copy

--- a/views/legacy/fontawesome.pug
+++ b/views/legacy/fontawesome.pug
@@ -16,7 +16,7 @@ block content
                 .form-group.my-4
                     label.font-weight-bold(for=formId) Complete CSS
                     .input-group.input-group-lg
-                        input.form-control(id=formId, type='text', value=file)
+                        input.form-control(id=formId, type='text', readonly, value=file)
                         .input-group-append
                             button.btn.btn-dark.dropdown-toggle(type='button', data-toggle='collapse', data-target=`#${name}`, aria-label='Toggle Dropdown', aria-expanded='false', aria-controls=name)
                     span.form-text.text-muted Click to copy


### PR DESCRIPTION
Fixes #1377 

@patrickhlauke: LGTY?

Preview: <https://bootstrapcdn-dev-pr-1379.herokuapp.com/>

Also, @jmervine @jdorfman if you like the change; it changes the look, but I believe this is technically more correct. So, since copying, focus etc works, I think this should be fine.