### PR TITLE
Go back to the deprecated `url.parse`

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -2,6 +2,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const url = require('url');
 const semver = require('semver');
 const sri = require('sri-toolbox');
 
@@ -108,11 +109,10 @@ function getTheme(selected) {
 function appendLocals(req, res) {
     const siteUrl = getCurrentSiteurl(req);
     const pageUrl = req.originalUrl;
-    // OK, hack-ish way...
-    const pathname = pageUrl.split('?')[0];
-    const canonicalUrl = new URL(pathname, app.siteurl);
+    // eslint-disable-next-line node/no-deprecated-api
+    const canonicalUrl = url.resolve(app.siteurl, url.parse(pageUrl).pathname);
     const theme = selectedTheme(req.query.theme);
-    const bodyClass = generateBodyClass(pathname);
+    const bodyClass = generateBodyClass(pageUrl);
 
     const locals = {
         siteUrl,


### PR DESCRIPTION
While deprecated, it's much cleaner to use this when we have relative URLs. It also appears to be a lot faster.

Also, there's an open issue about this in Node.js nodejs/node#12682