### PR TITLE
Revert "functional_test.js: Use a Set for the responses' cache."

### DIFF
--- a/test/functional_test.js
+++ b/test/functional_test.js
@@ -14,8 +14,6 @@ const { files } = require('../config');
 const helpers = require('./test_helpers');
 
 const CDN_URL = 'https://stackpath.bootstrapcdn.com/';
-
-const cache = new Set();
 const responses = {};
 
 // Expects header names to be lowercase in this object.
@@ -87,13 +85,12 @@ function domainCheck(uri) {
 
 function request(uri, cb) {
     // return memoized response to avoid making the same http call twice
-    if (cache.has(uri)) {
+    if (Object.prototype.hasOwnProperty.call(responses, uri)) {
         return cb(responses[uri]);
     }
 
     // build memoized response
     return helpers.prefetch(uri, (res) => {
-        cache.add(uri);
         responses[uri] = res;
         cb(res);
     });


### PR DESCRIPTION
This reverts commit 64df4227921385e345edc82432a3fc17656d4ea0.