### PR TITLE
Tweak theme query

### DIFF
--- a/routes/appendLocals.js
+++ b/routes/appendLocals.js
@@ -26,7 +26,7 @@ function getThemeQuery(req) {
     const query = req.query.theme;
 
     // Safety checks
-    if (Number.isNaN(query) || query < 0 || query >= totalThemes) {
+    if (!Number.parseInt(query, 10) || query < 0 || query >= totalThemes) {
         return '';
     }
 

--- a/test/bootswatch4_test.js
+++ b/test/bootswatch4_test.js
@@ -46,15 +46,15 @@ describe('bootswatch4', () => {
     });
 
     const invalidQueries = [
-        Number.parseInt(-1, 10),
-        Number.parseInt(500, 10),
-        Number.parseInt('5', 10),
-        Number.parseInt('foobar', 10)
+        -1,
+        500,
+        '5',
+        'foobar'
     ];
 
-    invalidQueries.forEach((i) => {
-        it(`handles invalid theme query parameter (${i})`, (done) => {
-            const invalidUri = helpers.getURI(`bootswatch/?theme=${i}`);
+    invalidQueries.forEach((query) => {
+        it(`handles invalid theme query parameter (${query})`, (done) => {
+            const invalidUri = helpers.getURI(`bootswatch/?theme=${query}`);
             let invalidResponse = {};
 
             helpers.prefetch(invalidUri, (res) => {


### PR DESCRIPTION
Use `Number.parseInt` since we expect this to be an integer.

@jmervine I think this is a better solution, WDYT?