### PR TITLE
Run the actions only on PRs and pushes to master and develop

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,12 +1,15 @@
-# https://github.com/github/codeql-action
-
-name: "Code Scanning - Action"
+name: Code Scanning - Action
 
 on:
   push:
+    branches:
+      - master
+      - develop
   pull_request:
+    branches:
+      - "**"
   schedule:
-    - cron: '0 0 * * 0'
+    - cron: "0 0 * * 0"
 
 jobs:
   CodeQL-Build:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,14 @@
 name: Lint
-on: [push, pull_request]
+
+on:
+  push:
+    branches:
+      - master
+      - develop
+  pull_request:
+    branches:
+      - "**"
+
 env:
   CI: true
   NODE: 12.x

--- a/.github/workflows/test-cdn.yml
+++ b/.github/workflows/test-cdn.yml
@@ -1,5 +1,14 @@
 name: CDN Tests
-on: [push, pull_request]
+
+on:
+  push:
+    branches:
+      - master
+      - develop
+  pull_request:
+    branches:
+      - "**"
+
 env:
   CI: true
   NODE: 12.x

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,14 @@
 name: Tests
-on: [push, pull_request]
+
+on:
+  push:
+    branches:
+      - master
+      - develop
+  pull_request:
+    branches:
+      - "**"
+
 env:
   CI: true
   NODE: 12.x


### PR DESCRIPTION
Since we always make PRs before something is merged, this should remove duplicate runs.